### PR TITLE
Fix domain param to a value in cluster.domain

### DIFF
--- a/src/agent/ansible/roles/env_k8s/post/templates/dnscontroller.j2
+++ b/src/agent/ansible/roles/env_k8s/post/templates/dnscontroller.j2
@@ -70,7 +70,7 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        - --domain=fabricnet.
+        - --domain= {{ cluster.domain }}.
         - --dns-port=10053
         - --kubecfg-file=/kube-config
         - --config-dir=/kube-dns-config


### PR DESCRIPTION
when create a kubedns container in the kube-dns pod, domain name is hardcoded as "fabricnet". This part makes kube network not working properly, when developers set the domain value as they like. To approve flexibilities, kube domain value needed to set to cluster.domain value in the file like cello/src/agent/ansible/vars/aws.yml.