### PR TITLE
Removed the read only header in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**Note:** This is a **read-only mirror** of the formal [Gerrit](https://gerrit.hyperledger.org/r/#/admin/projects/cello) repository. Find more details at [Cello Wiki](https://wiki.hyperledger.org/projects/cello).
-
 ![Cello](docs/images/logo.png)
 
 Hyperledger Cello is a blockchain provision and operation system, which helps manage blockchain networks in an efficient way.


### PR DESCRIPTION
The README.md doc contains a statement indicating
that the repository is read only, which was true
before we moved to github. Now we are on the github,
that statement is no longer true. This patch removes
that statement.