### PR TITLE
In product mode, api engine docs can not find static files

### DIFF
--- a/build_image/docker/common/nginx/nginx.conf.default
+++ b/build_image/docker/common/nginx/nginx.conf.default
@@ -45,7 +45,7 @@ http {
         #access_log  logs/host.access.log  main;
 
         location $URL_PREFIX/static {
-            alias /var/www/server/static;
+            alias /var/www/static;
         }
 
         location $URL_PREFIX {


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Expected Behavior
<!--- Tell us what should happen -->

## Current Behavior
<!--- Tell us what happens instead of the expected behavior -->
static files can't find, directory mapping is wrong
![截屏2019-10-23下午1 23 48](https://user-images.githubusercontent.com/35512917/67360408-764b6f00-f598-11e9-8976-12bae9ed48eb.png)


## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
should change /var/www/server/static to /var/www/static for static files mapping.

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. make start

## Context (Environment)
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->

<!--- Provide a general summary of the issue in the Title above -->

## Detailed Description
<!--- Provide a detailed description of the change or addition you are proposing -->

## Possible Implementation
<!--- Not obligatory, but suggest an idea for implementing addition or change -->
