### PR TITLE
[Fix #42] Fix nginx server media url not working

### DIFF
--- a/bootup/docker-compose-files/docker-compose.yml
+++ b/bootup/docker-compose-files/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     environment:
     - UWSGI_SERVER_HOST=api-engine
     - URL_PREFIX=${API_ENGINE_WEBROOT}
+    volumes:
+      - /opt/cello/api-engine/media:/var/www/media
 
   postgres-server:
     image: postgres:11.1

--- a/build_image/docker/common/nginx/nginx.conf.default
+++ b/build_image/docker/common/nginx/nginx.conf.default
@@ -48,6 +48,10 @@ http {
             alias /var/www/static;
         }
 
+        location $URL_PREFIX/media {
+            alias /var/www/media;
+        }
+
         location $URL_PREFIX {
                 include         uwsgi_params;
                 uwsgi_pass      api_server;


### PR DESCRIPTION
Add media url configuration in nginx.conf.
Mount media path from host for nginx server.