### PR TITLE
[CE-715]Fixed the fabric operator image path issue

### DIFF
--- a/src/agent/fabric-operator/README.md
+++ b/src/agent/fabric-operator/README.md
@@ -30,9 +30,13 @@ customresourcedefinition.apiextensions.k8s.io/peers.fabric.hyperledger.org creat
 ```
 Once the operator crds get created, start up the controller using the following command
 ```
-kubectl apply -f https://github.com/hyperledger/cello/blob/master/src/agent/fabric-operator/deploy/operator.yaml?raw=true
+kubectl apply \
+  -f https://github.com/hyperledger/cello/blob/master/src/agent/fabric-operator/deploy/service_account.yaml?raw=true \
+  -f https://github.com/hyperledger/cello/blob/master/src/agent/fabric-operator/deploy/role.yaml?raw=true \
+  -f https://github.com/hyperledger/cello/blob/master/src/agent/fabric-operator/deploy/role_binding.yaml?raw=true \
+  -f https://github.com/hyperledger/cello/blob/master/src/agent/fabric-operator/deploy/operator.yaml?raw=true
 ```
-The above command starts up the fabric operator controller in your k8s cluster. If your k8s cluster already have the controller running, you can skip these steps.
+The above command starts up the fabric operator controller in your k8s cluster. If your k8s cluster already has the controller running, you can skip this step.
 
 ### [Stand up a Fabric CA node](#startupca)
 

--- a/src/agent/fabric-operator/deploy/operator.yaml
+++ b/src/agent/fabric-operator/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: fabric-operator
           # Replace this with the built image name
-          image: hyperledger/fabric-operator:latest
+          image: hyperledger/cello-fabric-operator:latest
           command:
           - fabric-operator
           imagePullPolicy: Always


### PR DESCRIPTION
[CE-715]Since the fabric operator image is now officially
being placed on docker hub, we need to change the
operator deployment script to reflect that change
and modify the README.md accordingly. This patch
fixes these issues.