### PR TITLE
[Fix #47] Fix node status check crash for k8s agent

### DIFF
--- a/src/agent/kubernetes-agent/src/operations/create_node.py
+++ b/src/agent/kubernetes-agent/src/operations/create_node.py
@@ -137,7 +137,7 @@ def _create_fabric_node():
     node_status = NodeStatus.Error.value
     for i in range(1, MAX_QUERY_RETRY):
         pod = k8s_client.get_pod(AGENT_ID, deploy_name)
-        if pod.status.phase == "Running":
+        if pod and pod.status.phase == "Running":
             node_status = NodeStatus.Running.value
             break
         sleep(5)


### PR DESCRIPTION
For k8s agent node creation, node status check need
check whether pod is not None at first.