### PR TITLE
[Fix #50] Add api engine service port into dashboard

### DIFF
--- a/bootup/docker-compose-files/docker-compose-dev.yml
+++ b/bootup/docker-compose-files/docker-compose-dev.yml
@@ -94,5 +94,6 @@ services:
       - api-engine
     environment:
       - API_PROXY=http://api-engine:8080/engine
+      - SERVICE_PORT=$API_ENGINE_SERVICE_PORT
     ports:
       - "${DASHBOARD_SERVICE_PORT}:80"

--- a/bootup/docker-compose-files/docker-compose.yml
+++ b/bootup/docker-compose-files/docker-compose.yml
@@ -106,5 +106,6 @@ services:
       - nginx
     environment:
       - API_PROXY=http://nginx:80/engine
+      - SERVICE_PORT=$API_ENGINE_SERVICE_PORT
     ports:
       - "${DASHBOARD_SERVICE_PORT}:80"

--- a/build_image/docker/common/dashboard/config-nginx.sh
+++ b/build_image/docker/common/dashboard/config-nginx.sh
@@ -2,4 +2,4 @@
 
 NGINX_RAW_CONFIG=/etc/nginx/conf.d/default.conf.tmpl
 NGINX_CONFIG=/etc/nginx/conf.d/default.conf
-envsubst '$$API_PROXY' < ${NGINX_RAW_CONFIG} > ${NGINX_CONFIG}
+envsubst '$$API_PROXY,$$SERVICE_PORT' < ${NGINX_RAW_CONFIG} > ${NGINX_CONFIG}

--- a/build_image/docker/common/dashboard/default.conf.tmpl
+++ b/build_image/docker/common/dashboard/default.conf.tmpl
@@ -20,7 +20,7 @@ server {
 	location /api {
         proxy_pass $API_PROXY;
         proxy_set_header   X-Forwarded-Proto $scheme;
-        proxy_set_header   Host              $host;
+        proxy_set_header   Host              $host:$SERVICE_PORT;
         proxy_set_header   X-Real-IP         $remote_addr;
     }
 }


### PR DESCRIPTION
Add api engine service port info into dashboard,
and replace with varbiale in default.conf.tmpl.