### PR TITLE
[#80] Ansible agent fails create daemonset on k8s 1.16

### DIFF
--- a/src/agent/ansible/roles/deploy_k8s/fabricsetup/templates/fabric-services.j2
+++ b/src/agent/ansible/roles/deploy_k8s/fabricsetup/templates/fabric-services.j2
@@ -152,7 +152,7 @@ spec:
 
 {% if fabric.metrics is defined and fabric.metrics %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nodemetricds


### PR DESCRIPTION
When agent tried to create daemonset to monitor the node
performance, the daemonset was still using v1beta which
has been removed in k8s v1.16. This fix will move it up
to apps/v1.