### PR TITLE
fix(build): fix dashboard image build failed because of network

### DIFF
--- a/build_image/dockerhub/latest/common/dashboard/Dockerfile
+++ b/build_image/dockerhub/latest/common/dashboard/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="github.com/hyperledger/cello"
 WORKDIR /usr/src/app/
 USER root
 COPY --from=downloader /tmp/cello-master/src/dashboard ./
-RUN yarn install && yarn run build
+RUN npm i && npm run build
 
 FROM nginx:1.15.12
 


### PR DESCRIPTION
use npm instead of yarn to install package

fix #135

Signed-off-by: Haitao Yue <haitao.yue@easy-visible.com>