### PR TITLE
Fixed fabric operator default settings

### DIFF
--- a/src/agent/fabric-operator/deploy/crs/fabric_v1alpha1_ca_cr.yaml
+++ b/src/agent/fabric-operator/deploy/crs/fabric_v1alpha1_ca_cr.yaml
@@ -6,9 +6,6 @@ spec:
   # The CA admin id and password to start up a CA server
   admin: "sampleadmin"
   adminPassword: "samplepassword"
-  # Specify storage being used by this Certificate Authority.
-  # storageClass: "default"
-  # storageSize: "1Gi"
 
   # If you have an set of certs that you like to use instead of
   # generating a set by Fabric CA, you can specify as the following.
@@ -21,9 +18,13 @@ spec:
   #   tlsKey:
   nodeSpec:
     # Specify Fabric binaries to be used to setup the fabric CA
-    image: "hyperledger/fabric-ca:1.4.3"
+    image: "hyperledger/fabric-ca:1.4"
   # Optionally, FQDN can also be specified
   # hosts: ["ca.sample.com", "169.45.20.0"]
+
+  # Specify storage being used by this Certificate Authority.
+  # storageClass: "default"
+  # storageSize: "1Gi"
 
   # To specify resource limits for this CA node,
   # use kubernetes resource requirements spec

--- a/src/agent/fabric-operator/deploy/crs/fabric_v1alpha1_orderer_cr.yaml
+++ b/src/agent/fabric-operator/deploy/crs/fabric_v1alpha1_orderer_cr.yaml
@@ -30,7 +30,7 @@ spec:
     #     cpu: "250"
     storageSize: "1Gi"
     storageClass: "default"
-    image: "hyperledger/fabric-orderer:1.4.3"
+    image: "hyperledger/fabric-orderer:2.1"
   # Add any configurable orderer parameters as name-value pairs
     configParams:
       - name: ORDERER_GENERAL_TLS_ENABLED

--- a/src/agent/fabric-operator/deploy/crs/fabric_v1alpha1_peer_cr.yaml
+++ b/src/agent/fabric-operator/deploy/crs/fabric_v1alpha1_peer_cr.yaml
@@ -30,7 +30,7 @@ spec:
     #     cpu: "250"
     storageSize: "1Gi"
     storageClass: "default"
-    image: "hyperledger/fabric-peer:1.4.3"
+    image: "hyperledger/fabric-peer:2.1"
     # Add all the configurable peer parameters as
     # name-value pairs
     configParams:

--- a/src/agent/fabric-operator/go.mod
+++ b/src/agent/fabric-operator/go.mod
@@ -1,7 +1,6 @@
 module github.com/hyperledger/cello/src/agent/fabric-operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/go-openapi/spec v0.19.0
 	github.com/operator-framework/operator-sdk v0.9.1-0.20190806200632-6c7039c37324
 	github.com/spf13/pflag v1.0.3


### PR DESCRIPTION
CA node default settings has storageClass and storageSize in
the wrong place. This PR will fix that and also move the
default version of the fabric to 1.4 for ca and 2.1 for peer
and orderer.

Signed-off-by: Tong Li <litong01@us.ibm.com>