### PR TITLE
Clean the potential existing msp and tls paths

### DIFF
--- a/build_image/docker/cello-hlf/scripts/init.sh
+++ b/build_image/docker/cello-hlf/scripts/init.sh
@@ -36,6 +36,14 @@ cmd=$1
 # The path to store the files
 cfg_path=${FABRIC_CFG_PATH:-/etc/hyperledger/fabric}
 
+# Clean the potential existing msp and tls paths first
+if [ ! -z "${HLF_NODE_MSP}" ] && [ -d ${cfg_path}/msp ]; then
+    mv ${cfg_path}/msp ${cfg_path}/msp.bak
+fi
+if [ ! -z "${HLF_NODE_TLS}" ] && [ -d ${cfg_path}/tls ]; then
+    mv ${cfg_path}/tls ${cfg_path}/tls.bak
+fi
+
 # Read each file from env and store under the ${cfg_path}
 for name in HLF_NODE_MSP \
 	HLF_NODE_TLS \


### PR DESCRIPTION
When the msp or tls path exists, currently, the init.sh will merge the
parsed files into it. This may trigger peer's booting failure.

This patchset fixes the issue by cleaning the path when the
corresponding env variable exists and the target path is not empty.

Signed-off-by: Baohua Yang <yangbaohua@gmail.com>