### PR TITLE
Update Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,12 @@
 | Baohua Yang | yeasy | baohua | yangbaohua@gmail.com |
 | Haitao Yue | hightall | hightall | hightallyht@gmail.com |
 | Tong Li | tongli | tongli | litong01@us.ibm.com |
+| Qiang Xu | XuHugo | XuHugo | xq-310@163.com |
+
+## Retired Maintainers
+
+| Name | GitHub | RocketChat | Email |
+|---|---|---|---|
 | Luke Chen | LordGoodman | luke_chen | jiahaochen1993@gmail.com |
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Nominate Qiang Xu as new maintainer. He has leaded the user dashboard
development for quite a while, and actively attend the meeting
discussions with code contributions.

Retire inactive maintainer Luke Chen. Thanks a lot for his
contributions.

Signed-off-by: Baohua Yang <yangbaohua@gmail.com>