### PR TITLE
Fix rest_framework_jwt can not return the correct UserProfile.

### DIFF
--- a/src/api-engine/api/utils/customized_jwt_handlers.py
+++ b/src/api-engine/api/utils/customized_jwt_handlers.py
@@ -1,0 +1,10 @@
+def jwt_get_user_id_from_payload_handler(payload):
+    """
+    Return user id from payload.
+
+    :param payload: encoded JSON object.
+    :return: user id.
+    :rtype: string.
+
+    """
+    return payload.get("user_id")

--- a/src/api-engine/api_engine/settings.py.example
+++ b/src/api-engine/api_engine/settings.py.example
@@ -168,6 +168,7 @@ AUTH_USER_MODEL = 'api.UserProfile'
 JWT_AUTH = {
     'JWT_EXPIRATION_DELTA': datetime.timedelta(days=7),
     'JWT_RESPONSE_PAYLOAD_HANDLER': 'api.utils.jwt.jwt_response_payload_handler',
+    'JWT_PAYLOAD_GET_USERNAME_HANDLER': 'api.utils.customized_jwt_handlers.jwt_get_user_id_from_payload_handler',
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION
Fixed #290 rest_framework_jwt can not return the correct UserProfile object by adding customized payload_handler. we need to configure JWT_AUTH on settings.py 
```
'JWT_PAYLOAD_GET_USERNAME_HANDLER': 'api.utils.customized_jwt_handlers.jwt_get_user_id_from_payload_handler',
```



Signed-off-by: Yuanmao Zhu <zhu.yuanmao18@gmail.com>