### PR TITLE
Update Dockerfile.in

### DIFF
--- a/build_image/docker/agent/ansible/Dockerfile.in
+++ b/build_image/docker/agent/ansible/Dockerfile.in
@@ -10,10 +10,10 @@ ARG uid=1000
 ARG gid=1000
 
 RUN apt-get update                                          && \
-    apt-get install -y bash curl python-dev sudo               \
-    python-pip build-essential openssh-client libffi-dev       \
+    apt-get install -y bash curl python3-dev sudo               \
+    python3-pip build-essential openssh-client libffi-dev       \
     libssl-dev                                              && \
-    pip install --upgrade pip ansible pyyaml                && \
+    pip3 install --upgrade pip ansible pyyaml                && \
     groupadd -g ${gid} ${user}                              && \
     useradd -d /opt/agent -u ${uid} -g ${user} ${user}      && \
     usermod -a -G root ${user}                              && \

--- a/build_image/docker/agent/ansible/Dockerfile.in
+++ b/build_image/docker/agent/ansible/Dockerfile.in
@@ -1,7 +1,7 @@
 # Dockerfile for hyperledger cello ansible agent
 #
 # @see https://github.com/hyperledger/cello/blob/master/docs/worker_ansible_howto.md
-#
+
 FROM python:3.6
 MAINTAINER Hyperledger Cello Team <github.com/hyperledger/cello>
 


### PR DESCRIPTION
update python3 in build_image/docker/agent/ansible/Dockerfile.in. Because Ubuntu: latest is version 20.04, there is no Python-pip source, so errors will be executed all the time