### PR TITLE
[#issue-320] lifecycle_query_installed&lifecycle_get_installed_package

### DIFF
--- a/src/api-engine/api/lib/peer/chaincode.py
+++ b/src/api-engine/api/lib/peer/chaincode.py
@@ -1,6 +1,7 @@
 import os
+import json
 from api.lib.peer.basicEnv import BasicEnv
-from api.config import FABRIC_TOOL
+from api.config import FABRIC_TOOL, FABRIC_CFG
 
 
 class ChainCode(BasicEnv):
@@ -39,3 +40,49 @@ class ChainCode(BasicEnv):
             err_msg = "install chaincode failed for {}!".format(e)
             raise Exception(err_msg)
         return res
+
+    def lifecycle_query_installed(self, timeout):
+        """
+            get the chaincode info installed in peer.
+        :param timeout:
+        :return: res 0 means success
+                 installed_chaincodes: the json format of installed_chaincodes info
+        """
+
+        try:
+            res = os.system("{} lifecycle chaincode queryinstalled --output json --connTimeout {}"
+                            " > ./queryInstalled.txt".format(self.peer, timeout))
+            with open('./queryInstalled.txt', 'r', encoding='utf-8') as f:
+                content = f.read()
+            os.system("rm ./queryInstalled.txt")
+            installed_chaincodes = json.loads(content)
+        except Exception as e:
+            err_msg = "query_installed chaincode info failed for {}!".format(e)
+            raise Exception(err_msg)
+        return res, installed_chaincodes
+
+    def lifecycle_get_installed_package(self, timeout):
+        """
+            lifecycle_query_installed will return a list installed in peer.
+            then execute cmd to get all chaincode with tar.gz format installed in peer.
+        :param timeout:
+        :return: res_return: 0 means success get all chaincode in peers.
+        """
+        try:
+            res, installed = self.lifecycle_query_installed("3s")
+            res_return = 0
+            if res == 0:
+                for item in installed['installed_chaincodes']:
+                    res_get = os.system("{} lifecycle chaincode getinstalledpackage --package-id {} "
+                                        "--output-directory {} --connTimeout {}".format(self.peer,
+                                                                                        item['package_id'], FABRIC_CFG, timeout))
+                    res_get = res_get >> 8
+                    res_return = res_return or res_get
+            else:
+                print("package_id get failed.")
+                return 1, {}
+        except Exception as e:
+            err_msg = "get_installed_package failed for {}!".format(e)
+            raise Exception(err_msg)
+        return res_return
+


### PR DESCRIPTION
lifecycle_query_installed will get all chaincode information installed in peer. lifecycle_get_installed_package will get all chaincode files installed in peer,
it's input is packid_id.

Close #issue-320

Signed-off-by: zhaoshihong<523713078@qq.com>