### PR TITLE
Download binary files in docker image building process. 

### DIFF
--- a/build_image/docker/common/api-engine/Dockerfile.in
+++ b/build_image/docker/common/api-engine/Dockerfile.in
@@ -15,7 +15,7 @@ COPY src/api-engine ./
 COPY template/node  /opt/node
 
 # Install compiled code tools from Artifactory and copy it to opt folder.
-RUN curl -X GET "https://hyperledger.jfrog.io/artifactory/fabric-binaries/hyperledger-fabric-linux-amd64-2.2-stable.tar.gz?archiveType=gzip" > bin.tar.gz \
+RUN curl "https://hyperledger.jfrog.io/artifactory/fabric-binaries/hyperledger-fabric-linux-amd64-2.2-stable.tar.gz?archiveType=gzip" > bin.tar.gz \
 	&& tar -xzvf bin.tar.gz -C /opt/
 
 # Install python dependencies


### PR DESCRIPTION
Modified api-engine docker file, so the compiled code tools will be downloaded in the images building process. 

Signed-off-by: Yuanmao Zhu <zhu.yuanmao18@gmail.com>