### PR TITLE
Update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,8 +3,8 @@
 | Name | GitHub | RocketChat | Email |
 |---|---|---|---|
 | Baohua Yang | yeasy | baohua | yangbaohua@gmail.com |
-| Haitao Yue | hightall | hightall | hightallyht@gmail.com |
 | Qiang Xu | XuHugo | XuHugo | xq-310@163.com |
+| Yang Feng | fengyangsy | fengyangsy | fengyang.09186@h3c.com |
 
 ## Retired Maintainers
 
@@ -12,5 +12,6 @@
 |---|---|---|---|
 | Luke Chen | LordGoodman | luke_chen | jiahaochen1993@gmail.com |
 | Tong Li | tongli | tongli | litong01@us.ibm.com |
+| Haitao Yue | hightall | hightall | hightallyht@gmail.com |
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Based on the project rule, we nominate active developers with more than
3 months contribution and retire those not active for more than 3
  months.

fengyang continues contributing code as the main frontend developer to
the project, and proposes features on the dashboard.

* Add fengyang as new maintainer
* Retire hightall from active maintainers

Signed-off-by: Baohua Yang <yangbaohua@gmail.com>