### PR TITLE
[#issue-365] Change the administrator to admin

### DIFF
--- a/src/api-engine/api/auth.py
+++ b/src/api-engine/api/auth.py
@@ -63,7 +63,7 @@ class IsAdminAuthenticated(BasePermission):
     def has_permission(self, request, view):
         return (
             request.user
-            and request.user.role == UserRole.Administrator.name.lower()
+            and request.user.role == UserRole.Admin.name.lower()
         )
 
 

--- a/src/api-engine/api/common/enums.py
+++ b/src/api-engine/api/common/enums.py
@@ -186,7 +186,7 @@ class ConsensusPlugin(ExtraEnum):
 
 @unique
 class UserRole(ExtraEnum):
-    Administrator = 0
+    Admin = 0
     Operator = 1
     User = 2
 

--- a/src/api-engine/api/models.py
+++ b/src/api-engine/api/models.py
@@ -131,8 +131,8 @@ class UserProfile(AbstractUser):
         return self.username
 
     @property
-    def is_administrator(self):
-        return self.role == UserRole.Administrator.name.lower()
+    def is_admin(self):
+        return self.role == UserRole.Admin.name.lower()
 
     @property
     def is_operator(self):

--- a/src/api-engine/api/routes/agent/views.py
+++ b/src/api-engine/api/routes/agent/views.py
@@ -90,7 +90,7 @@ class AgentViewSet(viewsets.ViewSet):
                 #         if request.user.organization
                 #         else ""
                 #     )
-                #     if request.user.is_administrator:
+                #     if request.user.is_admin:
                 #         query_filters.update({"organization__name": org_name})
                 if name:
                     query_filters.update({"name__icontains": name})
@@ -318,7 +318,7 @@ class AgentViewSet(viewsets.ViewSet):
         """
         try:
             try:
-                if request.user.is_administrator:
+                if request.user.is_admin:
                     agent = Agent.objects.get(id=pk)
                 else:
                     raise CustomError("User can't delete agent！")

--- a/src/api-engine/api/routes/node/views.py
+++ b/src/api-engine/api/routes/node/views.py
@@ -112,7 +112,7 @@ class NodeViewSet(viewsets.ViewSet):
                     query_filter.update({"type": node_type})
                 if name:
                     query_filter.update({"name__icontains": name})
-                if request.user.is_administrator:
+                if request.user.is_admin:
                     query_filter.update(
                         {"organization": request.user.organization}
                     )
@@ -439,7 +439,7 @@ class NodeViewSet(viewsets.ViewSet):
         """
         try:
             node = Node.objects.get(id=pk)
-            org = node.org
+            org = node.organization
             if org is None:
                 raise ResourceNotFound
             network = org.network


### PR DESCRIPTION
There is a problem with the background user's permission. It is admin when registering and administrator when verifying the permission of some background interfaces, resulting in the failure of the interface. Uniformly modify to admin

Close #issue-365

Signed-off-by: tianxuanhong <523713078@qq.com>