### PR TITLE
[#issue-368] chaincode files upload

### DIFF
--- a/build_image/docker/common/dashboard/Dockerfile.in
+++ b/build_image/docker/common/dashboard/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM node:14.2.0
+FROM node:14.13.1
 
 WORKDIR /usr/src/app/
 USER root

--- a/src/api-engine/api/config.py
+++ b/src/api-engine/api/config.py
@@ -8,3 +8,5 @@ FABRIC_CFG = "/opt/node"
 FABRIC_PEER_CFG = "/opt/node/peer.yaml.bak"
 FABRIC_ORDERER_CFG = "/opt/node/orderer.yaml.bak"
 FABRIC_CA_CFG = "/opt/node/ca.yaml.bak"
+
+FABRIC_CHAINCODE_STORE="/opt/chaincode"

--- a/src/api-engine/api/models.py
+++ b/src/api-engine/api/models.py
@@ -786,3 +786,27 @@ class Channel(models.Model):
         status = models.CharField(
             help_text="status of chainCode", max_length=128
         )
+
+
+class ChainCodes(models.Model):
+    id = models.UUIDField(
+        primary_key=True,
+        help_text="ID of ChainCode",
+        default=make_uuid,
+        editable=False,
+        unique=True)
+    name = models.CharField(
+        help_text="name of chainCode", max_length=128
+    )
+    version = models.CharField(
+        help_text="version of chainCode", max_length=128
+    )
+    creator = models.CharField(
+        help_text="creator of chainCode", max_length=128
+    )
+    language = models.CharField(
+        help_text="language of chainCode", max_length=128
+    )
+    create_ts = models.DateTimeField(
+        help_text="Create time of chainCode", auto_now_add=True
+    )

--- a/src/api-engine/api/routes/chaincode/serializers.py
+++ b/src/api-engine/api/routes/chaincode/serializers.py
@@ -21,11 +21,8 @@ class ChainCodePackageBody(serializers.Serializer):
     md5 = serializers.CharField(max_length=128, required=True)
     file = serializers.FileField()
 
-
     def validate(self, attrs):
         md5_get = self.md5_for_file(attrs["file"])
-        print("m: ", md5_get)
-        print("a: ", attrs["md5"])
         if md5_get != attrs["md5"]:
             raise serializers.ValidationError("md5 not same.")
         return super().validate(attrs)

--- a/src/api-engine/api/routes/chaincode/serializers.py
+++ b/src/api-engine/api/routes/chaincode/serializers.py
@@ -1,0 +1,65 @@
+from rest_framework import serializers
+from api.config import FABRIC_CHAINCODE_STORE
+
+from api.models import ChainCodes
+from api.common.serializers import ListResponseSerializer
+import hashlib
+
+
+def upload_to(instance, filename):
+    return '/'.join([FABRIC_CHAINCODE_STORE, instance.user_name, filename])
+
+
+class ChainCodeIDSerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="ChainCode ID")
+
+
+class ChainCodePackageBody(serializers.Serializer):
+    name = serializers.CharField(max_length=128, required=True)
+    version = serializers.CharField(max_length=128, required=True)
+    language = serializers.CharField(max_length=128, required=True)
+    md5 = serializers.CharField(max_length=128, required=True)
+    file = serializers.FileField()
+
+
+    def validate(self, attrs):
+        md5_get = self.md5_for_file(attrs["file"])
+        print("m: ", md5_get)
+        print("a: ", attrs["md5"])
+        if md5_get != attrs["md5"]:
+            raise serializers.ValidationError("md5 not same.")
+        return super().validate(attrs)
+
+    @staticmethod
+    def md5_for_file(chunks):
+        md5 = hashlib.md5()
+        for data in chunks:
+            md5.update(data)
+        return md5.hexdigest()
+
+
+class ChainCodeNetworkSerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="Network ID")
+    name = serializers.CharField(max_length=128, help_text="name of Network")
+
+
+class ChainCodeOrgListSerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="Organization ID")
+    name = serializers.CharField(
+        max_length=128, help_text="name of Organization")
+
+
+class ChainCodeResponseSerializer(ChainCodeIDSerializer, serializers.ModelSerializer):
+    id = serializers.UUIDField(help_text="ID of Channel")
+    network = ChainCodeNetworkSerializer()
+    organizations = ChainCodeOrgListSerializer(many=True)
+
+    class Meta:
+        model = ChainCodes
+        fields = ("id", "name", "version", "creator", "language", "create_ts")
+
+
+class ChannelListResponse(ListResponseSerializer):
+    data = ChainCodeResponseSerializer(many=True, help_text="ChianCode data")
+
+

--- a/src/api-engine/api/routes/chaincode/views.py
+++ b/src/api-engine/api/routes/chaincode/views.py
@@ -1,0 +1,53 @@
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+import os
+
+from drf_yasg.utils import swagger_auto_schema
+from api.config import FABRIC_CHAINCODE_STORE
+
+from api.common.serializers import PageQuerySerializer
+from api.auth import TokenAuth
+from api.utils.common import with_common_response
+
+from api.routes.chaincode.serializers import (
+    ChainCodePackageBody,
+    ChainCodeIDSerializer
+)
+from api.common import ok, err
+
+
+class ChainCodeViewSet(viewsets.ViewSet):
+    """Class represents Channel related operations."""
+    authentication_classes = (JSONWebTokenAuthentication, TokenAuth)
+
+    @swagger_auto_schema(
+        query_serializer=PageQuerySerializer,
+        responses=with_common_response(
+            {status.HTTP_201_CREATED: ChainCodeIDSerializer}
+        ),
+    )
+    def create(self, request):
+        serializer = ChainCodePackageBody(data=request.data)
+        if serializer.is_valid(raise_exception=True):
+            name = serializer.validated_data.get("name")
+            version = serializer.validated_data.get("version")
+            language = serializer.validated_data.get("language")
+            md5 = serializer.validated_data.get("md5")
+            file = serializer.validated_data.get("file")
+            try:
+                # 把文件放入项目的media文件夹中
+                file_path = os.path.join(FABRIC_CHAINCODE_STORE, md5)
+                if not os.path.exists(file_path):
+                    os.makedirs(file_path)
+                with open(os.path.join(file_path, file.name), 'wb') as f:
+                    for chunk in file.chunks():
+                        f.write(chunk)
+                    f.close()
+            except Exception as e:
+                return Response(
+                    err(e.args), status=status.HTTP_400_BAD_REQUEST
+                )
+        return Response(
+                    ok("success"), status=status.HTTP_200_OK
+                )

--- a/src/api-engine/api_engine/urls.py
+++ b/src/api-engine/api_engine/urls.py
@@ -35,6 +35,7 @@ from api.routes.user.views import UserViewSet
 from api.routes.file.views import FileViewSet
 from api.routes.general.views import RegisterViewSet,CustomObtainJSONWebToken
 from api.routes.channel.views import ChannelViewSet
+from api.routes.chaincode.views import ChainCodeViewSet
 
 
 DEBUG = getattr(settings, "DEBUG")
@@ -68,6 +69,7 @@ router.register("files", FileViewSet, basename="file")
 # router.register("login2", LoginViewSet, basename="login2")
 router.register("register", RegisterViewSet, basename="register")
 router.register("channels", ChannelViewSet, basename="channel")
+router.register("chaincodes", ChainCodeViewSet, basename="chaincode")
 
 urlpatterns = router.urls
 


### PR DESCRIPTION
The interface of chain code upload is added. Temporarily save the chain code in the / opt / chaincode / {MD5} directory. In the future, consider making the package function in an interface?

and modified dashboard dockerfile of base image node version from 14.2.0 to 14.13.1 , to resolve the dashboard build error: 
error strip-css-comments@5.0.0: The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "14.2.0"
error Found incompatible module.


Close #368

Signed-off-by: tianxuanhong1 <523713078@qq.com>