### PR TITLE
Remove hardcode for publishing ports of HLF nodes. 

### DIFF
--- a/src/agent/docker-rest-agent/server.py
+++ b/src/agent/docker-rest-agent/server.py
@@ -40,6 +40,7 @@ def create_node():
     'HLF_NODE_PEER_CONFIG':request.form.get('peer_config_file'),
     'HLF_NODE_ORDERER_CONFIG':request.form.get('orderer_config_file'),
     }
+    port_map = ast.literal_eval(request.form.get("port_map"))
     if request.form.get('type') == "peer":
         peer_envs = {
             'CORE_VM_ENDPOINT': 'unix:///host/var/run/docker.sock',
@@ -79,6 +80,7 @@ def create_node():
         }
         env.update(order_envs)
         volumes = ['/var/run/:/host/var/run/']
+        
 
     try:
         # same as `docker run -dit yeasy/hyperledge-fabric:2.2.0 -e VARIABLES``
@@ -92,7 +94,8 @@ def create_node():
             name=request.form.get('name'),
             dns_search=["."],
             volumes=volumes,
-            environment=env
+            environment=env,
+            ports=port_map
             )
     except:
         res['code'] = FAIL_CODE

--- a/src/agent/docker-rest-agent/server.py
+++ b/src/agent/docker-rest-agent/server.py
@@ -61,11 +61,6 @@ def create_node():
         }
         env.update(peer_envs)
         volumes = ['/var/run/:/host/var/run/']
-        port_map = {
-            "7051/tcp":"7051",
-            "17051/tcp": "17051"
-        }
-      
     else:
         order_envs = {  
             'FABRIC_LOGGING_SPEC':'DEBUG',
@@ -84,10 +79,6 @@ def create_node():
         }
         env.update(order_envs)
         volumes = ['/var/run/:/host/var/run/']
-        port_map = {
-            "7050/tcp":"7050",
-            "17050/tcp": "17050"
-        }
 
     try:
         # same as `docker run -dit yeasy/hyperledge-fabric:2.2.0 -e VARIABLES``
@@ -101,8 +92,8 @@ def create_node():
             name=request.form.get('name'),
             dns_search=["."],
             volumes=volumes,
-            environment=env, 
-            ports=port_map)
+            environment=env
+            )
     except:
         res['code'] = FAIL_CODE
         res['data'] = sys.exc_info()[0]

--- a/src/api-engine/api/lib/agent/docker/handler.py
+++ b/src/api-engine/api/lib/agent/docker/handler.py
@@ -32,6 +32,8 @@ class DockerAgent(AgentBase):
         :rtype: string
         """
         try:
+            port_map = {str(port.internal): str(port.external) for port in info.get("ports")}
+            
             data = {
                 'msp': info.get("msp")[2:-1],
                 'tls': info.get("tls")[2:-1],
@@ -42,7 +44,7 @@ class DockerAgent(AgentBase):
                 'cmd': 'bash /tmp/init.sh "peer node start"' if info.get("type") == "peer" else 'bash /tmp/init.sh "orderer"',
                 'name': info.get("name"),
                 'type': info.get("type"),
-                'port_map': info.get("ports").__repr__(),
+                'port_map': port_map.__repr__(),
                 'action': 'create'
             }
 


### PR DESCRIPTION
Since we are using the docker network instead, mapping ports from hosts
is no longer necessary here. I remove these lines of code in this pr.

Fix #377 

Signed-off-by: Yuanmao Zhu <yuanmao@ualberta.ca>