### PR TITLE
Add node status field to the response Node.

### DIFF
--- a/src/api-engine/api/routes/node/views.py
+++ b/src/api-engine/api/routes/node/views.py
@@ -135,6 +135,7 @@ class NodeViewSet(viewsets.ViewSet):
                         #"channel": str(node.organization.channel.id) if node.organization.channel else None,
                         "ports": node.port,
                         "created_at": node.created_at,
+                        "status": node.status
                     }
                     for node in nodes
                 ]


### PR DESCRIPTION
Node status should appear in the response of `GET /api/v1/nodes` endpoint now.

Signed-off-by: Yuanmao Zhu <yuanmao@ualberta.ca>