### PR TITLE
[#issue-439] Fix the issue of long debug info in http response body.

### DIFF
--- a/src/api-engine/api/routes/general/views.py
+++ b/src/api-engine/api/routes/general/views.py
@@ -5,7 +5,7 @@ import logging
 import base64
 
 from rest_framework import viewsets, status
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from rest_framework.response import Response
 from rest_framework_jwt.views import ObtainJSONWebToken
 from api.models import UserProfile, Organization
@@ -34,24 +34,39 @@ class RegisterViewSet(viewsets.ViewSet):
         try:
             serializer = RegisterBody(data=request.data)
             if serializer.is_valid(raise_exception=True):
-                username = serializer.validated_data.get("username")
+                #username = serializer.validated_data.get("username")
                 email = serializer.validated_data.get("email")
                 orgname = serializer.validated_data.get("orgName")
                 password = serializer.validated_data.get("password")
+
                 try:
-                    Organization.objects.get(name=orgname)
                     UserProfile.objects.get(email=email)
                 except ObjectDoesNotExist:
                     pass
-                except Exception as e:
+                except MultipleObjectsReturned:
                     return Response(
-                        err(e), status=status.HTTP_409_CONFLICT
+                        err("Email Aleady exists!"), status=status.HTTP_409_CONFLICT
                     )
                 else:
                     return Response(
-                        err("orgnization exists!"), status=status.HTTP_409_CONFLICT
+                        err("Email Aleady exists!"), status=status.HTTP_409_CONFLICT
                     )
 
+                try:
+                    Organization.objects.get(name=orgname)
+                except ObjectDoesNotExist:
+                    pass
+                except MultipleObjectsReturned:
+                    return Response(
+                        err("Orgnization already exists!"), status=status.HTTP_409_CONFLICT
+                    )
+                else:
+                    return Response(
+                        err("Orgnization already exists!"), status=status.HTTP_409_CONFLICT
+                    )
+                
+
+                
                 CryptoConfig(orgname).create(0, 0)
                 CryptoGen(orgname).generate()
 

--- a/src/dashboard/src/services/api.js
+++ b/src/dashboard/src/services/api.js
@@ -1,8 +1,6 @@
-import { extend } from 'umi-request';
-// import request from '@/utils/request';
-const request = extend({
-  credentials: 'include',
-});
+//import { extend } from 'umi-request';
+import request from '@/utils/request';
+
 // eslint-disable-next-line import/prefer-default-export
 export async function fakeAccountLogin(params) {
   return request('/api/v1/login', {

--- a/src/dashboard/src/utils/request.js
+++ b/src/dashboard/src/utils/request.js
@@ -31,6 +31,14 @@ const errorHandler = error => {
 
   if (status === 400) {
     const api = url.split('/').pop();
+
+    if (api === 'login'){
+      notification.error({
+        message: '用户名或密码错误。',
+      });
+      return;
+    }
+
     if (api === 'token-verify') {
       verifyUserFail = true;
     }
@@ -47,6 +55,18 @@ const errorHandler = error => {
     });
     return;
   }
+
+  if (status === 409){
+    const api = url.split('/').pop();
+    if (api === 'register'){
+      notification.error({
+        message: '邮箱地址或组织名已存在。',
+      });
+      return;
+    }
+
+  }
+
   notification.error({
     message: `请求错误 ${status}: ${url}`,
     description: errortext,


### PR DESCRIPTION
[#issue-439] Fix the issue of long debug info in http response body.

Cause of issue:

```python3
# at src/dashboard/src/utils/request.js
Line 48: err(e), status=status.HTTP_409_CONFLICT

```
err(e) contains all the debug information, and should be replaced with a better error message.

Solution:
replace object e with better error messages like 'Email Aleady exists!'.

Additional Features:
I implemented notifications for login and register error message in dashboard.

Signed-off-by: ada2468 jx2161@nyu.edu