### PR TITLE
fix:(security): Path Traversal in download.py

### DIFF
--- a/src/agent/kubernetes-agent/src/utils/download.py
+++ b/src/agent/kubernetes-agent/src/utils/download.py
@@ -12,7 +12,7 @@ def download_file(url, target_dir):
     content_type = r.headers["content-type"]
     extension = mimetypes.guess_extension(content_type)
     file_name = "%s%s" % (uuid4().hex, extension)
-    target_file = os.path.join(target_dir, file_name)
+    target_file = os.path.join(target_dir, secure(file_name))
 
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)


### PR DESCRIPTION
Unsanitized input from ```r.headers``` and ```content_type = r.headers["content-type"]
    extension = mimetypes.guess_extension(content_type)
    file_name = "%s%s" % (uuid4().hex, extension)
    target_file = os.path.join(target_dir, secure(file_name))``` resource  flows into ```open(target_file, "wb").write(r.content)```, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to write arbitrary files.