### PR TITLE
Nominate yuanmao as new maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,8 +3,8 @@
 | Name | GitHub | RocketChat | Email |
 |---|---|---|---|
 | Baohua Yang | yeasy | baohua | yangbaohua@gmail.com |
-| Qiang Xu | XuHugo | XuHugo | xq-310@163.com |
 | Yang Feng | fengyangsy | fengyangsy | fengyang.09186@h3c.com |
+| Yuanmao Zhu | zhuyuanmao |  | yuanmao@ualberta.ca |
 
 ## Retired Maintainers
 
@@ -13,5 +13,6 @@
 | Luke Chen | LordGoodman | luke_chen | jiahaochen1993@gmail.com |
 | Tong Li | tongli | tongli | litong01@us.ibm.com |
 | Haitao Yue | hightall | hightall | hightallyht@gmail.com |
+| Qiang Xu | XuHugo | XuHugo | xq-310@163.com |
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Yuanmao continues contributing to the Cello project after his intern for
more than 3 months. He is working mainly on the API-engine component,
and the agent. Yuanmao is also very active in proposing features and
resolving implementation issues.

Retire inactive maintainer Qiang Xu, thanks for his past contributions!

Signed-off-by: Baohua Yang <yangbaohua@gmail.com>