### PR TITLE
Fix `dict` object has no attribute `urls` error in the get nodes endpoint

### DIFF
--- a/src/api-engine/api/routes/node/views.py
+++ b/src/api-engine/api/routes/node/views.py
@@ -120,23 +120,6 @@ class NodeViewSet(viewsets.ViewSet):
                 nodes = Node.objects.filter(**query_filter)
                 p = Paginator(nodes, per_page)
                 nodes = p.page(page)
-                nodes = [
-                    {
-                        "id": str(node.id),
-                        "name": node.name,
-                        "type": node.type,
-                        "organization": node.organization,
-                        "urls": node.urls,
-                        "network": str(node.organization.network.id) if node.organization.network else None,
-                        "agents": node.agent if node.agent else None,
-                        #"channel": str(node.organization.channel.id) if node.organization.channel else None,
-                        "ports": node.port,
-                        "created_at": node.created_at,
-                        "status": node.status
-                    }
-                    for node in nodes
-                ]
-
                 response = NodeListSerializer({"total": p.count, "data": nodes})
                 return Response(data=ok(response.data), status=status.HTTP_200_OK)
         except Exception as e:


### PR DESCRIPTION
Remove node conversion because we upgraded urls field from deprecated
JSON field to django4.0 supported one.

Signed-off-by: Yuanmao Zhu <yuanmao@ualberta.ca>