### PR TITLE
Improve observability on node and network creating process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ clean:
 
 deep-clean:
 	make clean
+	make remove-hyperledger-fabric-containers
 	make image-clean
 
 
@@ -235,6 +236,14 @@ remove-docker-compose:
 		rm -rf /opt/cello; \
 	fi
 	echo "Remove all services successfully"
+
+remove-hyperledger-fabric-containers:
+	echo "Remove all nodes ..."
+	if docker ps -a | grep "hyperledger-fabric"; then \
+		docker ps -a | grep "hyperledger-fabric" | awk '{print $1}' | xargs docker rm -f >/dev/null 2>&1; \
+		rm -rf /opt/hyperledger; \
+	fi
+	echo "Remove all nodes successfully"
 
 start-k8s:
 	@$(MAKE) -C bootup/kubernetes init-yaml

--- a/src/api-engine/api/routes/agent/views.py
+++ b/src/api-engine/api/routes/agent/views.py
@@ -167,7 +167,7 @@ class AgentViewSet(viewsets.ViewSet):
                         name=name
                     ).count()
                     if agent_count > 0:
-                        raise ResourceExists
+                        raise ResourceExists("Agent Exists")
 
                     body.update({"name": name})
 
@@ -176,7 +176,7 @@ class AgentViewSet(viewsets.ViewSet):
 
                 org = request.user.organization
                 if org.agent.all():
-                    raise ResourceExists
+                    raise ResourceExists("Agent Exists for the Organization")
                 else:
                     body.update({"organization": org})
 

--- a/src/api-engine/api/routes/network/views.py
+++ b/src/api-engine/api/routes/network/views.py
@@ -111,16 +111,16 @@ class NetworkViewSet(viewsets.ViewSet):
             node = Node.objects.get(id=pk)
             org = node.organization
             if org is None:
-                raise ResourceNotFound
+                raise ResourceNotFound(detail="Organization Not Found")
             network = org.network
             if network is None:
-                raise ResourceNotFound
+                raise ResourceNotFound(detail="Network Not Found")
             agent = org.agent.get()
             if agent is None:
-                raise ResourceNotFound
+                raise ResourceNotFound(detail="Agent Not Found")
             ports = Port.objects.filter(node=node)
             if ports is None:
-                raise ResourceNotFound
+                raise ResourceNotFound(detail="Port Not Found")
 
             info = {}
 
@@ -155,7 +155,7 @@ class NetworkViewSet(viewsets.ViewSet):
             if cid:
                 node_qs.update(cid=cid, status="running")
             else:
-                raise ResourceNotFound
+                raise ResourceNotFound(detail="Container Not Built")
         except Exception as e:
             raise e
 
@@ -181,12 +181,12 @@ class NetworkViewSet(viewsets.ViewSet):
 
                 try:
                     if Network.objects.get(name=name):
-                        raise ResourceExists
+                        raise ResourceExists(detail="Network exists")
                 except ObjectDoesNotExist:
                     pass
                 org = request.user.organization
                 if org.network:
-                    raise ResourceExists
+                    raise ResourceExists(detail="Network exists for the organization")
 
                 orderers = []
                 peers = []


### PR DESCRIPTION
* Add logs for `ResourceNotExists` Error.
* Create a command to remove all node containers.
* Tweak `deep-clean` command so then it can clean HLF nodes as well. 

Signed-off-by: Yuanmao Zhu <yuanmao@ualberta.ca>