### PR TITLE
fix(security):Command Injection and Path Traversal Bugs

### DIFF
--- a/src/api-engine/api/routes/chaincode/views.py
+++ b/src/api-engine/api/routes/chaincode/views.py
@@ -145,7 +145,7 @@ class ChainCodeViewSet(viewsets.ViewSet):
                 peer_channel_cli = PeerChainCode("v2.2.0", **envs)
                 res = peer_channel_cli.lifecycle_package(name, version, chaincode_path, language)
                 os.system("rm -rf {}/*".format(file_path))
-                os.system("mv {}.tar.gz {}".format(name, file_path))
+                os.system("mv {}.tar.gz {}".format(name, secure_file_path(file_path))
                 if res != 0:
                     return Response(err("package chaincode failed."), status=status.HTTP_400_BAD_REQUEST)
                 chaincode = ChainCode(
@@ -177,7 +177,7 @@ class ChainCodeViewSet(viewsets.ViewSet):
         try:
             cc_targz = ""
             file_path = os.path.join(FABRIC_CHAINCODE_STORE, chaincode_id)
-            for _, _, files in os.walk(file_path):
+            for _, _, files in os.walk(secure_file_path(file_path)):
                 cc_targz = os.path.join(file_path + "/" + files[0])
                 break
 

--- a/src/api-engine/api/routes/chaincode/views.py
+++ b/src/api-engine/api/routes/chaincode/views.py
@@ -145,7 +145,7 @@ class ChainCodeViewSet(viewsets.ViewSet):
                 peer_channel_cli = PeerChainCode("v2.2.0", **envs)
                 res = peer_channel_cli.lifecycle_package(name, version, chaincode_path, language)
                 os.system("rm -rf {}/*".format(file_path))
-                os.system("mv {}.tar.gz {}".format(name, secure_file_path(file_path))
+                os.system("mv {}.tar.gz {}".format(name, secure_file_path(file_path)))
                 if res != 0:
                     return Response(err("package chaincode failed."), status=status.HTTP_400_BAD_REQUEST)
                 chaincode = ChainCode(


### PR DESCRIPTION
## Fix 1 - Path Traversal

Unsanitized input from the HTTP request body [request.data] flows into os.walk, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.

## Fix 2 - Command Injection

Unsanitized input from the HTTP request body [request.data] flows into os.system, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.


Signed-off-by: Bhaskar <ram@hacker.ind.in>