### PR TITLE
Enable Github CI for Code Check

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,0 +1,26 @@
+name: Code Check CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Check code
+      run: make check 

--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,12 @@ check: ##@Code Check code format
 	@$(MAKE) license
 	find ./docs -type f -name "*.md" -exec egrep -l " +$$" {} \;
 	cd src/api-engine && tox && cd ${ROOT_PATH}
-	make docker
+	make api-engine
+	make docker-rest-agent
+	make dashboard
 	MODE=dev make start
 	sleep 10
-	make test-api
+	# make test-api
 	MODE=dev make stop
 	make check-dashboard
 

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -106,7 +106,7 @@
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-compat": "^2.6.3",
-    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-import": "2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-markdown": "^2.2.0",
     "eslint-plugin-react": "^7.12.4",


### PR DESCRIPTION
- Create yml file to run the code check CI.
- Fix version of eslint-plugin-import to avoid a known bug in it.
- Replace `make docker` in Makefile with new commands.

Signed-off-by: Xichen Pan <xichen.pan@gmail.com>