### PR TITLE
Implement API to get node config file

### DIFF
--- a/src/api-engine/api/routes/node/serializers.py
+++ b/src/api-engine/api/routes/node/serializers.py
@@ -325,6 +325,8 @@ class NodeOperationSerializer(serializers.Serializer):
         choices=Operation.to_choices(True),
     )
 
+class NodeConfigFileSerializer(serializers.ModelSerializer):
+    files = serializers.FileField()
 
 # class NodeFileCreateSerializer(serializers.ModelSerializer):
 #     def to_form_paras(self):

--- a/tests/postman/test/Hyperledger Cello Api Engine.postman_collection.json
+++ b/tests/postman/test/Hyperledger Cello Api Engine.postman_collection.json
@@ -2646,6 +2646,62 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Retrieve Node Config File",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "JWT {{token}}",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/zip",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://127.0.0.1:8080/api/v1/nodes/:node_id/config",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"v1",
+						"nodes",
+						":node_id",
+						"config"
+					],
+					"variable": [
+						{
+							"key": "node_id",
+							"value": "953bcca2-77c4-42e1-a496-d8efe0ea4ecc"
+						}
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"event": [


### PR DESCRIPTION
Enable to get config file through the api:
http://127.0.0.1:8080/api/v1/nodes/:node_id/config

A peer_config.zip or orderer_config.zip file will be returned.

Signed-off-by: Xichen Pan <xichen.pan@gmail.com>