### PR TITLE
Implement API to upload node config file

### DIFF
--- a/src/api-engine/api/routes/node/views.py
+++ b/src/api-engine/api/routes/node/views.py
@@ -9,8 +9,6 @@ import threading
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
-from django.core.files.storage import default_storage
-from django.core.files.base import ContentFile
 from django.http import HttpResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, status

--- a/tests/postman/test/Hyperledger Cello Api Engine.postman_collection.json
+++ b/tests/postman/test/Hyperledger Cello Api Engine.postman_collection.json
@@ -2702,6 +2702,70 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Upload Node Config File",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 202\", function () {",
+							"    pm.response.to.have.status(202);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "JWT {{token}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"type": "file",
+							"src": "/home/orderer.yaml"
+						}
+					]
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8080/api/v1/nodes/:node_id/config",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"v1",
+						"nodes",
+						":node_id",
+						"config"
+					],
+					"variable": [
+						{
+							"key": "node_id",
+							"value": "953bcca2-77c4-42e1-a496-d8efe0ea4ecc"
+						}
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"event": [


### PR DESCRIPTION
Enable to post and update config file through the api:
http://127.0.0.1:8080/api/v1/nodes/:node_id/config

orderer.yaml or core.yaml can be uploaded.
The corresponding yaml, zip files and database field will be updated.

Signed-off-by: Xichen Pan <xichen.pan@gmail.com>