### PR TITLE
Update docker-rest-agent Dep

### DIFF
--- a/src/agent/docker-rest-agent/requirements.txt
+++ b/src/agent/docker-rest-agent/requirements.txt
@@ -2,3 +2,4 @@ docker==4.3.1
 Flask==1.1.2
 gunicorn==20.0.4
 gevent==1.4
+greenlet==1.1.3


### PR DESCRIPTION
Update docker-rest-agent's dependency list by adding greenlet==1.1.3.

The gevent with a version lower than 20.9.0 will have difficulty working
with greenlet v2 or higher. If no greenlet version is specified, v2 or higher
will be installed automatically, which will crush gevent.

See [StackOverflow](https://stackoverflow.com/questions/34314222/gevent-not-valid-running-docker-registry) and [GitHub Issue](https://github.com/python-greenlet/greenlet/issues/178) for details.

Signed-off-by: xichen1 <xichen.pan@gmail.com>