### PR TITLE
Add token and user feilds to the response in token-verify endpoint

### DIFF
--- a/src/api-engine/api/routes/general/serializers.py
+++ b/src/api-engine/api/routes/general/serializers.py
@@ -31,3 +31,7 @@ class LoginBody(serializers.Serializer):
 class LoginSuccessBody(serializers.Serializer):
     token = serializers.CharField(help_text="access token")
     user = UserInfoSerializer()
+
+
+class TokenVerifyRequest(serializers.Serializer):
+    token = serializers.CharField(help_text="access token")

--- a/src/api-engine/api_engine/urls.py
+++ b/src/api-engine/api_engine/urls.py
@@ -25,7 +25,6 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import (
-    TokenVerifyView,
     TokenRefreshView,
 )
 from django.conf.urls.static import static
@@ -39,7 +38,10 @@ from api.routes.file.views import FileViewSet
 from api.routes.general.views import RegisterViewSet
 from api.routes.channel.views import ChannelViewSet
 from api.routes.chaincode.views import ChainCodeViewSet
-from api.routes.general.views import CelloTokenObtainPairView
+from api.routes.general.views import (
+    CelloTokenObtainPairView,
+    CelloTokenVerifyView,
+)
 
 
 DEBUG = getattr(settings, "DEBUG")
@@ -79,7 +81,7 @@ urlpatterns = router.urls
 urlpatterns += [
     path('login', CelloTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('login/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('token-verify', TokenVerifyView.as_view(), name='token_verify'),
+    path('token-verify', CelloTokenVerifyView.as_view(), name='token_verify'),
     path("docs/", SchemaView.with_ui("swagger", cache_timeout=0), name="docs"),
     path("redoc/", SchemaView.with_ui("redoc", cache_timeout=0), name="redoc"),
 ]


### PR DESCRIPTION
Example response 
```
{
    "data": {
        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjcwNjk5Njg0LCJpYXQiOjE2NzA2OTkzODQsImp0aSI6ImY1ZDc1MjUyMWJjNzQyMTVhOTQ5OTY0NWRhOTY3MmE0IiwidXNlcl9pZCI6ImEzODc4MDQwLTQ2MDItNDdlMy05YWE1LTYyYjI2OWMzN2VkOCJ9.W3dsf987YfX6c6yhaVssQF6MHxoBc6vF4HCNn8nS3Rw",
        "user": {
            "id": "a3878040-4602-47e3-9aa5-62b269c37ed8",
            "username": "foo2@email.com",
            "role": "admin",
            "organization": {
                "id": "142fb71a-ed52-4972-94ff-9c6b87f729d1",
                "name": "org2.cello.com"
            }
        }
    },
    "msg": null,
    "status": "successful"
}
```




Signed-off-by: Yuanmao Zhu <yuanmao@ualberta.ca>