### PR TITLE
Extend token expire duration

### DIFF
--- a/src/api-engine/api_engine/settings.py.example
+++ b/src/api-engine/api_engine/settings.py.example
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
-import datetime
+from datetime import timedelta
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -216,6 +216,7 @@ MEDIA_URL = "$WEBROOT/media/"
 CELERY_BROKER_URL = "$CELERY_BROKER_URL"
 
 SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),
     'ROTATE_REFRESH_TOKENS': False,
     'BLACKLIST_AFTER_ROTATION': False,
     'UPDATE_LAST_LOGIN': False,


### PR DESCRIPTION
The token would expire in 30 seconds originally if no request is sent from frontend.

Set the expiration time to 60 mins now.

Signed-off-by: xichen1 <xichen.pan@gmail.com>