### PR TITLE
Remove Delete Btn on Channel Page

### DIFF
--- a/src/dashboard/src/pages/Operator/Channel/Channel.js
+++ b/src/dashboard/src/pages/Operator/Channel/Channel.js
@@ -542,10 +542,6 @@ class Channel extends PureComponent {
             <a onClick={() => this.handleDownloadConfig(record)}>
               {intl.formatMessage({ id: 'form.menu.item.download', defaultMessage: 'Download' })}
             </a>
-            <Divider type="vertical" />
-            <a className={styles.danger}>
-              {intl.formatMessage({ id: 'form.menu.item.delete', defaultMessage: 'Delete' })}
-            </a>
           </Fragment>
         ),
       },


### PR DESCRIPTION
Channel page has a button to delete one channel. But we are going 
to implement this feature in the next release. So remove the frontend 
button for now.

Signed-off-by: xichen1 <xichen.pan@gmail.com>