### PR TITLE
Fix m1 Support Issue in #521

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ YELLOW := $(shell tput -Txterm setaf 3)
 RESET  := $(shell tput -Txterm sgr0)
 ARCH   := $(shell uname -m)
 
+# set the arm64 ARCH to amd64 for compatibility reason
+ifeq ($(ARCH), arm64)
+    ARCH := amd64
+endif
+
 #Set the source of PIP in docker agent image
 PIP=pip.conf.bak
 
@@ -46,6 +51,7 @@ DOCKER_BASE_x86_64=python:3.6
 DOCKER_BASE_ppc64le=ppc64le/python:3.6
 DOCKER_BASE_s390x=s390x/python:3.6
 DOCKER_BASE_arm64=python:3.6
+DOCKER_BASE_amd64=python:3.6
 DOCKER_BASE=$(DOCKER_BASE_$(ARCH))
 BASE_VERSION ?= $(ARCH)-$(VERSION)
 
@@ -211,11 +217,7 @@ stop-docker-compose:
 images: api-engine docker-rest-agent fabric dashboard
 
 api-engine: 
-	if [ "$(ARCH)" = "arm64" ]; then \
-		docker build -t hyperledger/cello-api-engine:latest -f build_image/docker/common/api-engine/Dockerfile.in ./ --platform linux/amd64; \
-	else \
-		docker build -t hyperledger/cello-api-engine:latest -f build_image/docker/common/api-engine/Dockerfile.in ./ --platform linux/$(ARCH); \
-	fi
+	docker build -t hyperledger/cello-api-engine:latest -f build_image/docker/common/api-engine/Dockerfile.in ./ --platform linux/$(ARCH)
 	
 docker-rest-agent:
 	docker build -t hyperledger/cello-agent-docker:latest -f build_image/docker/agent/docker-rest-agent/Dockerfile.in ./ --build-arg pip=$(PIP) --platform linux/$(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,11 @@ stop-docker-compose:
 images: api-engine docker-rest-agent fabric dashboard
 
 api-engine: 
-	docker build -t hyperledger/cello-api-engine:latest -f build_image/docker/common/api-engine/Dockerfile.in ./ --platform linux/$(ARCH)
+	if [ "$(ARCH)" = "arm64" ]; then \
+		docker build -t hyperledger/cello-api-engine:latest -f build_image/docker/common/api-engine/Dockerfile.in ./ --platform linux/amd64; \
+	else \
+		docker build -t hyperledger/cello-api-engine:latest -f build_image/docker/common/api-engine/Dockerfile.in ./ --platform linux/$(ARCH); \
+	fi
 	
 docker-rest-agent:
 	docker build -t hyperledger/cello-agent-docker:latest -f build_image/docker/agent/docker-rest-agent/Dockerfile.in ./ --build-arg pip=$(PIP) --platform linux/$(ARCH)


### PR DESCRIPTION
If current arch is arm64, use docker platform linux/amd64, 
still use linux/$(ARCH) platform for all other arches.