### PR TITLE
Upgrade Nginx Docker Image

### DIFF
--- a/build_image/docker/common/nginx/Dockerfile.in
+++ b/build_image/docker/common/nginx/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM nginx:1.15.7
+FROM nginx:1.24.0
 
 RUN apt-get update && apt-get install -y wget && \
 	apt-get autoclean && apt-get clean && apt-get autoremove && rm -rf /var/cache/apt/


### PR DESCRIPTION
Old Nginx docker image has compatibility issues with current Debian package manager. 
Therefore upgrade the image to the latest version. Fix [CI build failure](https://github.com/hyperledger/cello/actions/runs/4813462766/jobs/8570022172#step:3:709).