### PR TITLE
Upgrade FE test image

### DIFF
--- a/tests/dashboard/docker-compose.yml
+++ b/tests/dashboard/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   test-dashboard:
-    image: node:12.6.0-slim
+    image: node:14.17
     volumes:
       - $ROOT_PATH/src/dashboard:/dashboard
     working_dir: /dashboard


### PR DESCRIPTION
Based on the discussion in #536, upgrade the node image 
used by FE test to 14.17.