### PR TITLE
Nominate Xichen Pan as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,7 @@
 | Baohua Yang | yeasy | yangbaohua@gmail.com |
 | Yang Feng | fengyangsy | fengyang.09186@h3c.com |
 | Yuanmao Zhu | zhuyuanmao | yuanmao@ualberta.ca |
+| Xichen Pan | xichen1 | xichen.pan@gmail.com  |
 
 ## Retired Maintainers
 


### PR DESCRIPTION
Xichen Pan was the intern student last year, he is actively contributing into the project in terms of code, features, and bug fixes.

After his intern program, he continues to contribute to the project as an individual developer for more than half a year.

I believe the nomination will help the project move on more efficiently.