### PR TITLE
Bump MarkupSafe from 1.1.1 to 2.0.1 in api-engine

### DIFF
--- a/src/api-engine/requirements.txt
+++ b/src/api-engine/requirements.txt
@@ -27,7 +27,7 @@ Jinja2==2.11.3
 jsonpointer==2.0
 jsonschema==3.2.0
 kubernetes==11.0.0
-MarkupSafe==1.1.1
+MarkupSafe==2.0.1
 oauthlib==3.1.0
 packaging==20.4
 pathtools==0.1.2


### PR DESCRIPTION
Bump MarkupSafe to solve the dependency conflict in #591.

Signed-off-by: Xichen Pan <xichen.pan@gmail.com>