### PR TITLE
Resolved the permission issue for uploading chaincode

### DIFF
--- a/src/api-engine/api/config.py
+++ b/src/api-engine/api/config.py
@@ -11,4 +11,4 @@ FABRIC_PEER_CFG = "/opt/node/peer.yaml.bak"
 FABRIC_ORDERER_CFG = "/opt/node/orderer.yaml.bak"
 FABRIC_CA_CFG = "/opt/node/ca.yaml.bak"
 
-FABRIC_CHAINCODE_STORE = "/opt/chaincode"
+FABRIC_CHAINCODE_STORE = "/opt/cello/chaincode"


### PR DESCRIPTION
I got this error when uploading the chaincode: ```[Error 13] Permission denied: '/opt/chaincode'```
I resolved this by changing ```FABRIC_CHAINCODE_STORE = "/opt/chaincode"``` to ```FABRIC_CHAINCODE_STORE = "/opt/cello/chaincode"``` in the ```config.py``` file.