### PR TITLE
update glob(npm) for dashboard

### DIFF
--- a/build_image/docker/common/dashboard/Dockerfile.in
+++ b/build_image/docker/common/dashboard/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM node:14.18
+FROM node:16.20
 
 WORKDIR /usr/src/app/
 USER root

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -92,6 +92,7 @@
     "@types/history": "^4.7.2",
     "@types/react": "^16.8.1",
     "@types/react-dom": "^16.0.11",
+    "glob": "^9.0.0",
     "@umijs/preset-react": "^1.2.2",
     "antd-pro-merge-less": "^1.0.0",
     "antd-theme-webpack-plugin": "^1.2.0",
@@ -143,6 +144,7 @@
     "scripts/**/*.js"
   ],
   "resolutions": {
-    "mockjs/commander": "^8.2.0"
+    "mockjs/commander": "^8.2.0",
+    "glob": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Problem:
When I run the project, the following errors occur.

31.71 warning netlify-lambda > globby > glob@7.2.3: Glob versions prior to v9 are no longer supported
40.63 warning netlify-lambda > webpack > terser-webpack-plugin > cacache > glob@7.2.3: Glob versions prior to v9 are no longer supported
......
204.5 error glob@11.0.0: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "14.18.3"
204.5 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this ⌘.
204.5 error Found incompatible module

## Reason:
The original version of glob@7.2.3 is no longer supported. Manual update to version 9.0.0 required.