### PR TITLE
update node version to 20.15

### DIFF
--- a/build_image/docker/common/dashboard/Dockerfile.in
+++ b/build_image/docker/common/dashboard/Dockerfile.in
@@ -1,10 +1,10 @@
-FROM node:14.18
+FROM node:20.15
 
 WORKDIR /usr/src/app/
 USER root
 RUN mkdir -p /usr/src/app && cd /usr/src/app
 COPY src/dashboard /usr/src/app
-RUN yarn --network-timeout 600000 && yarn run build
+RUN export NODE_OPTIONS=--openssl-legacy-provider && yarn --network-timeout 600000 && yarn run build
 
 FROM nginx:1.15.12
 COPY --from=0 /usr/src/app/dist /usr/share/nginx/html


### PR DESCRIPTION
When I upgraded node to 20.15 only, the following error is reported:

node:internal/crypto/hash:79
  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
                  ^
The environment variable NODE_OPTIONS needs to be set manually to force Node.js to use OpenSSL's older APIs.