### PR TITLE
upgrade configtxgen to v2.5.9

### DIFF
--- a/src/api-engine/api/lib/configtxgen/configtxgen.py
+++ b/src/api-engine/api/lib/configtxgen/configtxgen.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from subprocess import call
-from api.config import CELLO_HOME, FABRIC_TOOL
+from api.config import CELLO_HOME, FABRIC_TOOL, FABRIC_VERSION
+
+import logging
+LOG = logging.getLogger(__name__)
 
 
 class ConfigTxGen:
     """Class represents cryptotxgen."""
 
-    def __init__(self, network, filepath=CELLO_HOME, configtxgen=FABRIC_TOOL, version="2.2.0"):
+    def __init__(self, network, filepath=CELLO_HOME, configtxgen=FABRIC_TOOL, version=FABRIC_VERSION):
         """init CryptoGen
                 param:
                     network: network's name
@@ -22,7 +25,7 @@ class ConfigTxGen:
         self.filepath = filepath
         self.version = version
 
-    def genesis(self, profile="TwoOrgsOrdererGenesis", channelid="testchainid", outputblock="genesis.block"):
+    def genesis(self, profile="", channelid="", outputblock="genesis.block"):
         """generate gensis
                 param:
                     profile: profile
@@ -31,27 +34,18 @@ class ConfigTxGen:
                 return:
         """
         try:
-            call([self.configtxgen, "-configPath", "{}/{}/".format(self.filepath, self.network),
-                  "-profile", "{}".format(profile),
-                  "-outputBlock", "{}/{}/{}".format(self.filepath, self.network, outputblock),
-                  "-channelID", "{}".format(channelid)])
-        except Exception as e:
-            err_msg = "configtxgen genesis fail! "
-            raise Exception(err_msg + str(e))
+            command = [
+                self.configtxgen,
+                "-configPath", "{}/{}/".format(self.filepath, self.network),
+                "-profile", "{}".format(profile),
+                "-outputBlock", "{}/{}/{}".format(self.filepath, self.network, outputblock),
+                "-channelID", "{}".format(channelid)
+            ]
 
-    def channeltx(self, profile, channelid, outputCreateChannelTx="channel.tx"):
-        """generate anchorpeer
-                param:
-                    profile: profile
-                    channelid: channelid
-                    outputblock: outputblock
-                return:
-        """
-        try:
-            call([self.configtxgen, "-configPath", "{}/{}/".format(self.filepath, self.network),
-                  "-profile", "{}".format(profile),
-                  "-outputCreateChannelTx", "{}/{}/{}".format(self.filepath, self.network, "channel-artifacts/" + outputCreateChannelTx),
-                  "-channelID", "{}".format(channelid)])
+            LOG.info("Running command: " + " ".join(command))
+
+            call(command)
+
         except Exception as e:
             err_msg = "configtxgen genesis fail! "
             raise Exception(err_msg + str(e))
@@ -65,7 +59,3 @@ class ConfigTxGen:
                 return:
         """
         pass
-
-
-if __name__ == "__main__":
-    ConfigTxGen("net").channeltx("testchannel", "testchannel")

--- a/src/api-engine/api/routes/channel/views.py
+++ b/src/api-engine/api/routes/channel/views.py
@@ -137,28 +137,34 @@ class ChannelViewSet(viewsets.ViewSet):
                     if p.status != "running":
                         raise NoResource
 
-                ConfigTX(org.network.name).createChannel(name, [org.name])
-                ConfigTxGen(org.network.name).channeltx(
-                    profile=name, channelid=name, outputCreateChannelTx="{}.tx".format(name))
-                tx_path = "{}/{}/channel-artifacts/{}.tx".format(
-                    CELLO_HOME, org.network.name, name)
-                block_path = "{}/{}/channel-artifacts/{}.block".format(
+                _orderers = []
+                _peers = []
+                _orderers.append({"name": org.name, "hosts": []})
+                _peers.append({"name": org.name, "hosts": []})
+                nodes = Node.objects.filter(organization=org)
+                for node in nodes:
+                    if node.type == "peer":
+                        _peers[0]["hosts"].append({"name": node.name})
+                    elif node.type == "orderer":
+                        _orderers[0]["hosts"].append({"name": node.name})
+
+                ConfigTX(org.network.name).create(name, org.network.consensus, _orderers, _peers)
+                ConfigTxGen(org.network.name).genesis(profile=name, channelid=name, outputblock="{}.block".format(name))
+
+                block_path = "{}/{}/{}.block".format(
                     CELLO_HOME, org.network.name, name)
                 ordering_node = Node.objects.get(id=orderers[0])
-                peer_node = Node.objects.get(id=peers[0])
-                envs = init_env_vars(peer_node, org)
-                peer_channel_cli = PeerChannel("v2.2.0", **envs)
+                envs = init_env_vars(ordering_node, org)
+                peer_channel_cli = PeerChannel(**envs)
                 peer_channel_cli.create(
                     channel=name,
                     orderer_url="{}.{}:{}".format(
-                        ordering_node.name, org.name.split(".", 1)[1], str(7050)),
-                    channel_tx=tx_path,
-                    output_block=block_path
+                        ordering_node.name, org.name.split(".", 1)[1], str(7053)),
+                    block_path=block_path
                 )
                 for i in range(len(peers)):
                     peer_node = Node.objects.get(id=peers[i])
                     envs = init_env_vars(peer_node, org)
-                    # envs["CORE_PEER_LOCALMSPID"] = '{}MSP'.format(peer_node.name.split(".")[0].capitalize()) #Org1MSP
                     join_peers(envs, block_path)
 
                 channel = Channel(

--- a/src/api-engine/api/routes/network/views.py
+++ b/src/api-engine/api/routes/network/views.py
@@ -177,7 +177,7 @@ class NetworkViewSet(viewsets.ViewSet):
             if serializer.is_valid(raise_exception=True):
                 name = serializer.validated_data.get("name")
                 consensus = serializer.validated_data.get("consensus")
-                # database = serializer.validated_data.get("database")
+                database = serializer.validated_data.get("database")
 
                 try:
                     if Network.objects.get(name=name):
@@ -189,24 +189,8 @@ class NetworkViewSet(viewsets.ViewSet):
                     raise ResourceExists(
                         detail="Network exists for the organization")
 
-                orderers = []
-                peers = []
-                orderers.append({"name": org.name, "hosts": []})
-                peers.append({"name": org.name, "hosts": []})
-                nodes = Node.objects.filter(organization=org)
-                for node in nodes:
-                    if node.type == "peer":
-                        peers[0]["hosts"].append({"name": node.name})
-                    elif node.type == "orderer":
-                        orderers[0]["hosts"].append({"name": node.name})
-
-                ConfigTX(name).create(consensus=consensus,
-                                      orderers=orderers, peers=peers)
-                ConfigTxGen(name).genesis()
-
-                block = self._genesis2base64(name)
                 network = Network(
-                    name=name, consensus=consensus, genesisblock=block)
+                    name=name, consensus=consensus, database=database)
                 network.save()
                 org.network = network
                 org.save()


### PR DESCRIPTION
### Summary of changes:
1. According to the latest [Configtxgen-Usage](https://hyperledger-fabric.readthedocs.io/en/latest/commands/configtxgen.html), "channeltx" function has been deprecated, which should be replaced by "genesis" function from _<src/api-engine/api/lib/configtxgen/configtxgen.py>_
2. Since the system channel is no longer supported (a system channel genesis block is unnecessary before creating a orderer service), delete the operations of configtx and configtxgen in the create func from _<src/api-engine/api/routes/network/views.py>._
3. Only perform genesis block creation once in channel's create function (configtxgen.genesis) from _<src/api-engine/api/routes/channel/views.py> ._