### PR TITLE
Remove operations related to system channel genesis block creation before creating orderer service

### DIFF
--- a/build_image/docker/cello-hlf/scripts/init.sh
+++ b/build_image/docker/cello-hlf/scripts/init.sh
@@ -5,7 +5,7 @@
 # It will read the following env variables
 # HLF_NODE_MSP: store a base64 encoded zipped "msp" path
 # HLF_NODE_TLS: store a base64 encoded zipped "tls" path
-# HLF_NODE_BOOTSTRAP_BLOCK: store a base64 encoded zipped bootstrap block
+# HLF_NODE_BOOTSTRAP_BLOCK: store a base64 encoded zipped bootstrap block, which is no longer needed for HLF 2.5.9 or higher versions
 # HLF_NODE_PEER_CONFIG: store a base64 encoded zipped peer configuration file (core.yaml)
 # HLF_NODE_ORDERER_CONFIG: store a base64 encoded zipped orderer configuration file (orderer.yaml)
 
@@ -47,7 +47,6 @@ fi
 # Read each file from env and store under the ${cfg_path}
 for name in HLF_NODE_MSP \
 	HLF_NODE_TLS \
-	HLF_NODE_BOOTSTRAP_BLOCK \
 	HLF_NODE_PEER_CONFIG \
 	HLF_NODE_ORDERER_CONFIG
 do

--- a/src/agent/docker-rest-agent/server.py
+++ b/src/agent/docker-rest-agent/server.py
@@ -37,7 +37,6 @@ def create_node():
     env = {
     'HLF_NODE_MSP': request.form.get('msp'),
     'HLF_NODE_TLS':request.form.get('tls'),
-    'HLF_NODE_BOOTSTRAP_BLOCK':request.form.get('bootstrap_block'),
     'HLF_NODE_PEER_CONFIG':request.form.get('peer_config_file'),
     'HLF_NODE_ORDERER_CONFIG':request.form.get('orderer_config_file'),
     'platform': 'linux/amd64',
@@ -72,9 +71,6 @@ def create_node():
             'FABRIC_LOGGING_SPEC':'DEBUG',
             'ORDERER_GENERAL_LISTENADDRESS': '0.0.0.0',
             'ORDERER_GENERAL_LISTENPORT': '7050',
-            'ORDERER_GENERAL_GENESISMETHOD':'file',
-            'ORDERER_GENERAL_LOCALMSPDIR': '/etc/hyperledger/fabric/msp',
-            'ORDERER_GENERAL_GENESISFILE': '/etc/hyperledger/fabric/genesis.block',
             'ORDERER_GENERAL_TLS_ENABLED': 'true',
             'ORDERER_GENERAL_TLS_PRIVATEKEY':'/etc/hyperledger/fabric/tls/server.key',
             'ORDERER_GENERAL_TLS_CERTIFICATE':'/etc/hyperledger/fabric/tls/server.crt',
@@ -82,6 +78,15 @@ def create_node():
             'ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE': '/etc/hyperledger/fabric/tls/server.crt',
             'ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY': '/etc/hyperledger/fabric/tls/server.key',
             'ORDERER_GENERAL_CLUSTER_ROOTCAS': '[/etc/hyperledger/fabric/tls/ca.crt]',
+            'ORDERER_GENERAL_LOCALMSPDIR': '/etc/hyperledger/fabric/msp',
+            'ORDERER_GENERAL_LOCALMSPID': 'OrdererMSP',
+
+            "ORDERER_ADMIN_LISTENADDRESS": "0.0.0.0:7053",
+            "ORDERER_ADMIN_TLS_ENABLED": "true",
+            "ORDERER_ADMIN_TLS_CERTIFICATE": "/etc/hyperledger/fabric/tls/server.crt",
+            "ORDERER_ADMIN_TLS_PRIVATEKEY": "/etc/hyperledger/fabric/tls/server.key",
+            "ORDERER_ADMIN_TLS_CLIENTROOTCAS": "[/etc/hyperledger/fabric/tls/ca.crt]",
+            "ORDERER_ADMIN_TLS_CLIENTAUTHREQUIRED": "true"
         }
         env.update(order_envs)
     try:

--- a/src/api-engine/api/lib/agent/docker/handler.py
+++ b/src/api-engine/api/lib/agent/docker/handler.py
@@ -38,10 +38,9 @@ class DockerAgent(AgentBase):
             data = {
                 'msp': info.get("msp")[2:-1],
                 'tls': info.get("tls")[2:-1],
-                'bootstrap_block': info.get("bootstrap_block")[2:-1],
                 'peer_config_file': info.get("config_file")[2:-1],
                 'orderer_config_file': info.get("config_file")[2:-1],
-                'img': 'yeasy/hyperledger-fabric:2.2.0',
+                'img': 'hyperledger/fabric:2.5.9',
                 'cmd': 'bash /tmp/init.sh "peer node start"' if info.get("type") == "peer" else 'bash /tmp/init.sh "orderer"',
                 'name': info.get("name"),
                 'type': info.get("type"),

--- a/src/api-engine/api/routes/network/views.py
+++ b/src/api-engine/api/routes/network/views.py
@@ -132,7 +132,6 @@ class NetworkViewSet(viewsets.ViewSet):
             info["config_file"] = node.config_file
             info["type"] = node.type
             info["name"] = "{}.{}".format(node.name, org_name)
-            info["bootstrap_block"] = network.genesisblock
             info["urls"] = agent.urls
             info["network_type"] = network.type
             info["agent_type"] = agent.type

--- a/src/api-engine/api/routes/node/views.py
+++ b/src/api-engine/api/routes/node/views.py
@@ -417,11 +417,8 @@ class NodeViewSet(viewsets.ViewSet):
             a = NodeConfig(org)
             a.peer(node, **args)
         else:
-            args.update({"General_ListenPort": 7050})
-            args.update(
-                {"General_LocalMSPID": "{}OrdererMSP".format(org.capitalize())})
-            args.update({"General_TLS_Enabled": True})
-            args.update({"General_BootstrapFile": "genesis.block"})
+            args.update({"General_BootstrapMethod": "none"})
+            args.update({"ChannelParticipation_Enabled": True})
 
             a = NodeConfig(org)
             a.orderer(node, **args)
@@ -458,7 +455,6 @@ class NodeViewSet(viewsets.ViewSet):
             info["config_file"] = node.config_file
             info["type"] = node.type
             info["name"] = "{}.{}".format(node.name, org_name)
-            info["bootstrap_block"] = network.genesisblock
             info["urls"] = agent.urls
             info["network_type"] = network.type
             info["agent_type"] = agent.type

--- a/src/api-engine/api/routes/organization/views.py
+++ b/src/api-engine/api/routes/organization/views.py
@@ -231,7 +231,6 @@ class OrganizationViewSet(viewsets.ViewSet):
             args.update(
                 {"General_LocalMSPID": "{}OrdererMSP".format(org.capitalize())})
             args.update({"General_TLS_Enabled": True})
-            args.update({"General_BootstrapFile": "genesis.block"})
 
             a = NodeConfig(org)
             a.orderer(node, **args)


### PR DESCRIPTION
As HLFv2.5.9 [Channel Creation](https://hyperledger-fabric.readthedocs.io/en/latest/create_channel/create_channel_participation.html), system channels are no longer supported, which means the creation of orderer service container no longer require system channel genesis block.