### PR TITLE
fix(ci): use check-api target in dashandapi_post pipeline

### DIFF
--- a/ci/dashandapi_post.yml
+++ b/ci/dashandapi_post.yml
@@ -6,7 +6,7 @@ steps:
 - script: |
     MODE=dev make start
     sleep 10
-    make test-api
+    make check-api
     MODE=dev make stop
     make check-dashboard
   displayName: 'Run API and Dashboard tests'


### PR DESCRIPTION
Fixes #778

Updated the CI command in ci/dashandapi_post.yml to use the correct Make target.

Before
Pipeline step called make test-api (target not present in active Makefile).

After
Pipeline step now calls make check-api (target exists in active Makefile).

The active root Makefile defines check-api and does not define test-api.

