### PR TITLE
feat: Add channel member (#772)

### DIFF
--- a/src/api-engine/channel/serializers.py
+++ b/src/api-engine/channel/serializers.py
@@ -3,9 +3,10 @@ from typing import Dict, Any
 from rest_framework import serializers
 
 from channel.models import Channel
-from channel.service import create
+from channel.service import create, add_organization_to_channel
 from common.serializers import ListResponseSerializer
 from node.service import organization_orderer_exists, organization_peer_exists
+from organization.models import Organization
 from organization.serializers import OrganizationID
 
 
@@ -47,3 +48,31 @@ class ChannelCreateBody(serializers.Serializer):
         return ChannelID(create(
             self.context["organization"],
             validated_data["name"]))
+
+
+class AddOrganizationBody(serializers.Serializer):
+    organization_id = serializers.UUIDField(required=True)
+
+    def validate_organization_id(self, value) -> Organization:
+        try:
+            org = Organization.objects.get(pk=value)
+        except Organization.DoesNotExist:
+            raise serializers.ValidationError(
+                f"Organization with id {value} does not exist."
+            )
+        return org
+
+    def validate(self, attrs):
+        channel: Channel = self.context["channel"]
+        new_org: Organization = attrs["organization_id"]
+        if channel.organizations.filter(pk=new_org.pk).exists():
+            raise serializers.ValidationError(
+                "Organization is already a member of this channel."
+            )
+        return attrs
+
+    def save(self, **kwargs) -> Channel:
+        channel: Channel = self.context["channel"]
+        new_org: Organization = self.validated_data["organization_id"]
+        return add_organization_to_channel(channel, new_org)
+

--- a/src/api-engine/channel/service.py
+++ b/src/api-engine/channel/service.py
@@ -22,3 +22,22 @@ def create(
     res = Channel.objects.create(name=channel_name)
     res.organizations.add(channel_organization)
     return res
+
+
+def add_organization_to_channel(
+        channel: Channel,
+        new_organization: Organization) -> Channel:
+    """Join a new organization to an existing channel.
+
+    Calls the new organization's agent to join the channel, then records
+    the relationship in the database.
+    """
+    agent_url = new_organization.agent_url
+    requests.get(urljoin(agent_url, "health")).raise_for_status()
+    requests.post(
+        urljoin(agent_url, f"channels/{channel.name}/organizations"),
+        json=dict(channel=channel.name)
+    ).raise_for_status()
+
+    channel.organizations.add(new_organization)
+    return channel

--- a/src/api-engine/channel/views.py
+++ b/src/api-engine/channel/views.py
@@ -1,14 +1,17 @@
-from django.core.paginator import Paginator
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets, status
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from api.common import ok
 from api.common.response import make_response_serializer
 from channel.models import Channel
-from channel.serializers import ChannelList, ChannelID, ChannelResponse, ChannelCreateBody
-from common.responses import with_common_response
+from channel.serializers import (
+    ChannelList, ChannelID, ChannelResponse, ChannelCreateBody,
+    AddOrganizationBody,
+)
+from common.responses import with_common_response, err
 from common.serializers import PageQuerySerializer
 
 
@@ -51,3 +54,57 @@ class ChannelViewSet(viewsets.ViewSet):
             status=status.HTTP_201_CREATED,
             data=ok(serializer.save().data)
         )
+
+    @swagger_auto_schema(
+        operation_summary="Get details of a specific channel",
+        responses=with_common_response(
+            {status.HTTP_200_OK: make_response_serializer(ChannelResponse)}
+        ),
+    )
+    def retrieve(self, request, pk=None):
+        try:
+            channel = Channel.objects.get(
+                pk=pk,
+                organizations__id__contains=request.user.organization.id,
+            )
+        except Channel.DoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data=err("Channel not found"),
+            )
+        return Response(
+            status=status.HTTP_200_OK,
+            data=ok(ChannelResponse(channel).data),
+        )
+
+    @swagger_auto_schema(
+        operation_summary="Add an organization to an existing channel",
+        request_body=AddOrganizationBody(),
+        responses=with_common_response(
+            {status.HTTP_200_OK: make_response_serializer(ChannelResponse)}
+        ),
+    )
+    @action(detail=True, methods=["POST"])
+    def add_organization(self, request, pk=None):
+        try:
+            channel = Channel.objects.get(
+                pk=pk,
+                organizations__id__contains=request.user.organization.id,
+            )
+        except Channel.DoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data=err("Channel not found"),
+            )
+
+        serializer = AddOrganizationBody(
+            data=request.data,
+            context={"channel": channel},
+        )
+        serializer.is_valid(raise_exception=True)
+        updated_channel = serializer.save()
+        return Response(
+            status=status.HTTP_200_OK,
+            data=ok(ChannelResponse(updated_channel).data),
+        )
+

--- a/src/dashboard/src/locales/en-US/Channel.js
+++ b/src/dashboard/src/locales/en-US/Channel.js
@@ -21,4 +21,11 @@ export default {
   'app.channel.form.update.checkMSPId': 'Please enter MSP id',
   'app.channel.form.update.file': 'Channel config file',
   'app.channel.form.update.fileSelect': 'Please select channel config file',
+  'app.channel.form.addOrg.success': 'Add organization succeed',
+  'app.channel.form.addOrg.fail': 'Add organization failed',
+  'app.channel.form.addOrg.header.title': 'Add Organization',
+  'app.channel.form.addOrg.organization': 'Organization',
+  'app.channel.form.addOrg.required.organization': 'Please select an Organization.',
+  'app.channel.table.operate.update': 'Update',
+  'app.channel.table.operate.addOrg': 'Add Organization',
 };

--- a/src/dashboard/src/locales/zh-CN/Channel.js
+++ b/src/dashboard/src/locales/zh-CN/Channel.js
@@ -21,4 +21,11 @@ export default {
   'app.channel.form.update.checkMSPId': '请输入MSP ID',
   'app.channel.form.update.file': '通道配置文件',
   'app.channel.form.update.fileSelect': '请选择通道配置文件',
+  'app.channel.form.addOrg.success': '添加组织成功',
+  'app.channel.form.addOrg.fail': '添加组织失败',
+  'app.channel.form.addOrg.header.title': '添加组织',
+  'app.channel.form.addOrg.organization': '组织',
+  'app.channel.form.addOrg.required.organization': '请选择组织',
+  'app.channel.table.operate.update': '更新',
+  'app.channel.table.operate.addOrg': '添加组织',
 };

--- a/src/dashboard/src/models/channel.js
+++ b/src/dashboard/src/models/channel.js
@@ -1,7 +1,13 @@
 /*
  SPDX-License-Identifier: Apache-2.0
 */
-import { listChannel, createChannel, getNodeConfig, updateChannelConfig } from '@/services/channel';
+import {
+  listChannel,
+  createChannel,
+  getNodeConfig,
+  updateChannelConfig,
+  addOrgToChannel,
+} from '@/services/channel';
 import { createModel, createListEffect, createSimpleEffect } from '@/utils/modelFactory';
 
 export default createModel({
@@ -30,6 +36,14 @@ export default createModel({
     // Custom effect for updateChannel with special parameter structure
     *updateChannel({ id, payload, callback }, { call }) {
       const response = yield call(updateChannelConfig, id, payload);
+      if (callback) {
+        callback(response);
+      }
+    },
+
+    // Add an organization to an existing channel
+    *addOrgToChannel({ id, payload, callback }, { call }) {
+      const response = yield call(addOrgToChannel, id, payload);
       if (callback) {
         callback(response);
       }

--- a/src/dashboard/src/pages/Channel/Channel.js
+++ b/src/dashboard/src/pages/Channel/Channel.js
@@ -264,10 +264,117 @@ const UpdateChannel = props => {
   );
 };
 
-const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating, updating }) => {
+const AddOrganization = props => {
+  const [form] = Form.useForm();
+  const intl = useIntl();
+  const {
+    addOrgModalVisible,
+    handleAddOrg,
+    handleModalVisible,
+    addingOrg,
+    fetchChannels,
+    channelData,
+    organizations = [],
+  } = props;
+
+  const addCallback = response => {
+    if (response && response.status === 'successful') {
+      message.success(
+        intl.formatMessage({
+          id: 'app.channel.form.addOrg.success',
+          defaultMessage: 'Add organization succeed',
+        })
+      );
+      form.resetFields();
+      handleModalVisible();
+      fetchChannels();
+    } else {
+      message.error(
+        intl.formatMessage({
+          id: 'app.channel.form.addOrg.fail',
+          defaultMessage: 'Add organization failed',
+        })
+      );
+    }
+  };
+
+  const onSubmit = () => {
+    form.submit();
+  };
+
+  const onFinish = values => {
+    handleAddOrg(channelData.id, values, addCallback);
+  };
+
+  const orgOptions = organizations.map(item => (
+    <Option value={item.id} key={item.id}>
+      <span>{item.name}</span>
+    </Option>
+  ));
+
+  const formItemLayout = {
+    labelCol: {
+      xs: { span: 24 },
+      sm: { span: 7 },
+    },
+    wrapperCol: {
+      xs: { span: 24 },
+      sm: { span: 12 },
+      md: { span: 10 },
+    },
+  };
+
+  return (
+    <Modal
+      destroyOnClose
+      title={intl.formatMessage({
+        id: 'app.channel.form.addOrg.header.title',
+        defaultMessage: 'Add Organization',
+      })}
+      confirmLoading={addingOrg}
+      open={addOrgModalVisible}
+      onOk={onSubmit}
+      onCancel={() => handleModalVisible(false)}
+    >
+      <Form onFinish={onFinish} form={form} preserve={false}>
+        <FormItem
+          {...formItemLayout}
+          label={intl.formatMessage({
+            id: 'app.channel.form.addOrg.organization',
+            defaultMessage: 'Organization',
+          })}
+          name="organization_id"
+          rules={[
+            {
+              required: true,
+              message: intl.formatMessage({
+                id: 'app.channel.form.addOrg.required.organization',
+                defaultMessage: 'Please select an Organization.',
+              }),
+            },
+          ]}
+        >
+          <Select>{orgOptions}</Select>
+        </FormItem>
+      </Form>
+    </Modal>
+  );
+};
+
+const Channel = ({
+  dispatch,
+  channel = {},
+  node = {},
+  organization = {},
+  loadingChannels,
+  creating,
+  updating,
+  addingOrg,
+}) => {
   const intl = useIntl();
   const { channels = [], pagination = {} } = channel;
   const { nodes = {} } = node;
+  const { organizations = [] } = organization;
 
   const { selectedRows, handleSelectRows, handleTableChange, refreshList } = useTableManagement({
     dispatch,
@@ -276,12 +383,14 @@ const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating,
 
   const [modalVisible, setModalVisible] = useState(false);
   const [updateModalVisible, setUpdateModalVisible] = useState(false);
+  const [addOrgModalVisible, setAddOrgModalVisible] = useState(false);
   const [channelData, setChannelData] = useState({});
   const [newFile, setFile] = useState(null);
 
   useEffect(() => {
     dispatch({ type: 'channel/listChannel' });
     dispatch({ type: 'node/listNode' });
+    dispatch({ type: 'organization/listOrganization' });
     return () => {
       dispatch({ type: 'channel/clear' });
     };
@@ -298,6 +407,11 @@ const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating,
 
   const handleUpdateModalVisible = useCallback((visible, record) => {
     setUpdateModalVisible(!!visible);
+    setChannelData(record || {});
+  }, []);
+
+  const handleAddOrgModalVisible = useCallback((visible, record) => {
+    setAddOrgModalVisible(!!visible);
     setChannelData(record || {});
   }, []);
 
@@ -326,6 +440,18 @@ const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating,
         type: 'channel/updateChannel',
         id,
         payload: formData,
+        callback,
+      });
+    },
+    [dispatch]
+  );
+
+  const handleAddOrg = useCallback(
+    (id, values, callback) => {
+      dispatch({
+        type: 'channel/addOrgToChannel',
+        id,
+        payload: values,
         callback,
       });
     },
@@ -369,6 +495,29 @@ const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating,
     ]
   );
 
+  const addOrgFormProps = useMemo(
+    () => ({
+      addOrgModalVisible,
+      handleAddOrg,
+      handleModalVisible: handleAddOrgModalVisible,
+      fetchChannels,
+      addingOrg,
+      channelData,
+      organizations,
+      intl,
+    }),
+    [
+      addOrgModalVisible,
+      handleAddOrg,
+      handleAddOrgModalVisible,
+      fetchChannels,
+      addingOrg,
+      channelData,
+      organizations,
+      intl,
+    ]
+  );
+
   const columns = [
     {
       title: intl.formatMessage({
@@ -382,6 +531,23 @@ const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating,
         id: 'form.table.header.operation',
         defaultMessage: 'Operation',
       }),
+      render: (text, record) => (
+        <>
+          <a onClick={() => handleUpdateModalVisible(true, record)}>
+            {intl.formatMessage({
+              id: 'app.channel.table.operate.update',
+              defaultMessage: 'Update',
+            })}
+          </a>
+          <span className={styles.splitLine} style={{ margin: '0 8px' }} />
+          <a onClick={() => handleAddOrgModalVisible(true, record)}>
+            {intl.formatMessage({
+              id: 'app.channel.table.operate.addOrg',
+              defaultMessage: 'Add Organization',
+            })}
+          </a>
+        </>
+      ),
     },
   ];
 
@@ -421,14 +587,17 @@ const Channel = ({ dispatch, channel = {}, node = {}, loadingChannels, creating,
       </Card>
       <CreateChannel {...formProps} />
       <UpdateChannel {...updateFormProps} />
+      <AddOrganization {...addOrgFormProps} />
     </PageHeaderWrapper>
   );
 };
 
-export default connect(({ channel, node, loading }) => ({
+export default connect(({ channel, node, organization, loading }) => ({
   channel,
   node,
+  organization,
   loadingChannels: loading.effects['channel/listChannel'],
   creating: loading.effects['channel/createChannel'],
   updating: loading.effects['channel/updateChannel'],
+  addingOrg: loading.effects['channel/addOrgToChannel'],
 }))(Channel);

--- a/src/dashboard/src/services/channel.js
+++ b/src/dashboard/src/services/channel.js
@@ -25,3 +25,10 @@ export const getNodeConfig = params =>
     responseType: 'json',
     getResponse: true,
   });
+
+// Add an organization to an existing channel
+export const addOrgToChannel = (id, params) =>
+  customRequest(`/api/v1/channels/${id}/add_organization`, {
+    method: 'POST',
+    data: params,
+  });


### PR DESCRIPTION
- Added add_organization API endpoint in the channel service
- Created AddOrganizationBody serializer with validation logic
- Updated frontend Channel services and Dva models to handle add_organization API calls
- Built the AddOrganization Modal component in the Channel dashboard
- Fetched organizations and provided a dropdown interface for selecting the organization
- Added necessary localization strings (en-US, zh-CN) for the new UI elements