### PR TITLE
POC: Read-only Claude Code skill for inspecting Cello via the REST API

### DIFF
--- a/.claude/skills/cello/SKILL.md
+++ b/.claude/skills/cello/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: cello
+description: Read the status of a Hyperledger Cello deployment through its REST API. Use when the user asks to inspect Cello, Fabric networks, nodes, peers, orderers, channels, chaincodes, or organizations.
+---
+
+# Cello API
+
+Read-only inspection of a running Cello API Engine.
+
+## Setup
+
+- **Base URL**: `http://localhost:8080/api/v1`
+- **Credentials**: read from `~/.cello/credentials`, an env-style file
+  with `CELLO_EMAIL=...` and `CELLO_PASSWORD=...` (create it once,
+  `chmod 600`).
+- **Auth**: send the JWT from `~/.cello/token` as the
+  `Authorization: JWT <token>` header. If `~/.cello/token` is
+  missing, run the login helper below first. Tokens expire after ~1
+  hour, so on any `401` re-run the helper and retry the request.
+
+Login helper:
+```bash
+mkdir -p ~/.cello
+set -a; . ~/.cello/credentials; set +a
+curl -s -X POST http://localhost:8080/api/v1/login \
+     -H "Content-Type: application/json" \
+     -d "{\"email\":\"$CELLO_EMAIL\",\"password\":\"$CELLO_PASSWORD\"}" \
+  | jq -r '.data.token' > ~/.cello/token
+```
+
+If `~/.cello/credentials` does not exist, ask the user to create it
+instead of guessing. If it exists but the helper writes an empty
+or `null` token, login failed — stop and ask the user to verify the
+credentials in that file and that the API Engine is reachable. Don't
+retry blindly.
+
+All responses are wrapped as `{status, msg, data}`. List endpoints
+paginate with `?page=1&per_page=10` (max per_page=100).
+
+## Topics — load the matching file as needed
+
+| User mentions… | Read this file |
+|----------------|----------------|
+| nodes, peers, orderers | `nodes.md` |
+| channels | `channels.md` |
+| chaincodes, smart contracts | `chaincodes.md` |
+| organizations, members | `organizations.md` |
+
+Load only the file relevant to the user's question, not all of them.

--- a/.claude/skills/cello/SKILL.md
+++ b/.claude/skills/cello/SKILL.md
@@ -26,16 +26,16 @@ curl -s -X POST http://localhost:8080/api/v1/login \
      -H "Content-Type: application/json" \
      -d "{\"email\":\"$CELLO_EMAIL\",\"password\":\"$CELLO_PASSWORD\"}" \
   | jq -r '.data.token' > ~/.cello/token
+chmod 600 ~/.cello/token
 ```
 
-If `~/.cello/credentials` does not exist, ask the user to create it
-instead of guessing. If it exists but the helper writes an empty
-or `null` token, login failed — stop and ask the user to verify the
-credentials in that file and that the API Engine is reachable. Don't
-retry blindly.
+If login fails or the token is empty or null, ask the user to verify
+`~/.cello/credentials` and API availability. Do not guess credentials.
 
-All responses are wrapped as `{status, msg, data}`. List endpoints
-paginate with `?page=1&per_page=10` (max per_page=100).
+Successful responses use `{status, msg, data}`; error responses may not.
+
+List endpoints default to `per_page=10`; use `per_page=100` for
+inspection and page further only when `.data.total > 100`.
 
 ## Topics — load the matching file as needed
 

--- a/.claude/skills/cello/chaincodes.md
+++ b/.claude/skills/cello/chaincodes.md
@@ -8,18 +8,19 @@ Fields: `id`, `name`, `version`, `sequence`, `init_required`,
 ### List chaincodes (name + version + status)
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/chaincodes \
+     'http://localhost:8080/api/v1/chaincodes?page=1&per_page=100' \
   | jq -r '.data.data[] | "\(.name) v\(.version) [\(.status)]"'
 ```
 
 ### Count
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/chaincodes | jq '.data.total'
+     'http://localhost:8080/api/v1/chaincodes?page=1&per_page=100' \
+  | jq '.data.total'
 ```
 
 ### Full details
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/chaincodes
+     'http://localhost:8080/api/v1/chaincodes?page=1&per_page=100'
 ```

--- a/.claude/skills/cello/chaincodes.md
+++ b/.claude/skills/cello/chaincodes.md
@@ -1,0 +1,25 @@
+# Chaincodes
+
+A chaincode is a smart contract deployed to a channel.
+Fields: `id`, `name`, `version`, `sequence`, `init_required`,
+`signature_policy`, `package_id`, `label`, `creator`, `channel`,
+`language`, `description`, `status`, `approvals`, `created_at`.
+
+### List chaincodes (name + version + status)
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/chaincodes \
+  | jq -r '.data.data[] | "\(.name) v\(.version) [\(.status)]"'
+```
+
+### Count
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/chaincodes | jq '.data.total'
+```
+
+### Full details
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/chaincodes
+```

--- a/.claude/skills/cello/channels.md
+++ b/.claude/skills/cello/channels.md
@@ -1,0 +1,23 @@
+# Channels
+
+A channel is a private communication subnet between organizations.
+Fields: `id`, `name`, `organizations` (list of `{id}` objects),
+`created_at`.
+
+### List channels (names)
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/channels | jq -r '.data.data[] | .name'
+```
+
+### Count
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/channels | jq '.data.total'
+```
+
+### Full details
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/channels
+```

--- a/.claude/skills/cello/channels.md
+++ b/.claude/skills/cello/channels.md
@@ -7,17 +7,19 @@ Fields: `id`, `name`, `organizations` (list of `{id}` objects),
 ### List channels (names)
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/channels | jq -r '.data.data[] | .name'
+     'http://localhost:8080/api/v1/channels?page=1&per_page=100' \
+  | jq -r '.data.data[] | .name'
 ```
 
 ### Count
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/channels | jq '.data.total'
+     'http://localhost:8080/api/v1/channels?page=1&per_page=100' \
+  | jq '.data.total'
 ```
 
 ### Full details
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/channels
+     'http://localhost:8080/api/v1/channels?page=1&per_page=100'
 ```

--- a/.claude/skills/cello/nodes.md
+++ b/.claude/skills/cello/nodes.md
@@ -7,14 +7,14 @@ Fields: `id`, `name`, `type` (PEER | ORDERER),
 ### List nodes (summary)
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/nodes \
+     'http://localhost:8080/api/v1/nodes?page=1&per_page=100' \
   | jq -r '.data.data[] | "\(.name) (\(.type), \(.status))"'
 ```
 
 ### Running peers only
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/nodes \
+     'http://localhost:8080/api/v1/nodes?page=1&per_page=100' \
   | jq -r '.data.data[]
           | select(.type=="PEER" and .status=="RUNNING") | .name'
 ```
@@ -22,11 +22,12 @@ curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
 ### Count
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/nodes | jq '.data.total'
+     'http://localhost:8080/api/v1/nodes?page=1&per_page=100' \
+  | jq '.data.total'
 ```
 
 ### Full details (use only when fields above are insufficient)
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/nodes
+     'http://localhost:8080/api/v1/nodes?page=1&per_page=100'
 ```

--- a/.claude/skills/cello/nodes.md
+++ b/.claude/skills/cello/nodes.md
@@ -1,0 +1,32 @@
+# Nodes
+
+A node is a peer or orderer in the Fabric network.
+Fields: `id`, `name`, `type` (PEER | ORDERER),
+`status` (CREATED | RUNNING | FAILED), `created_at`.
+
+### List nodes (summary)
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/nodes \
+  | jq -r '.data.data[] | "\(.name) (\(.type), \(.status))"'
+```
+
+### Running peers only
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/nodes \
+  | jq -r '.data.data[]
+          | select(.type=="PEER" and .status=="RUNNING") | .name'
+```
+
+### Count
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/nodes | jq '.data.total'
+```
+
+### Full details (use only when fields above are insufficient)
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/nodes
+```

--- a/.claude/skills/cello/organizations.md
+++ b/.claude/skills/cello/organizations.md
@@ -6,7 +6,7 @@ belongs to one. Fields exposed by the API: `id`, `name`, `created_at`.
 ### List organizations
 ```bash
 curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
-     http://localhost:8080/api/v1/organizations \
+     'http://localhost:8080/api/v1/organizations?page=1&per_page=100' \
   | jq -r '.data.data[] | "\(.name) [\(.id)]"'
 ```
 

--- a/.claude/skills/cello/organizations.md
+++ b/.claude/skills/cello/organizations.md
@@ -1,0 +1,17 @@
+# Organizations
+
+An organization is the top-level tenant. Each user and resource
+belongs to one. Fields exposed by the API: `id`, `name`, `created_at`.
+
+### List organizations
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/organizations \
+  | jq -r '.data.data[] | "\(.name) [\(.id)]"'
+```
+
+### Get one
+```bash
+curl -s -H "Authorization: JWT $(cat ~/.cello/token)" \
+     http://localhost:8080/api/v1/organizations/<ORG_ID>
+```


### PR DESCRIPTION
## Summary

This PR adds a POC skill that lets an AI coding agent inspect a running Cello deployment — nodes, channels, chaincodes, and organizations — through the **existing** REST API.

It is intentionally **read-only** and meant as a starting point.

## What's included

```
.claude/skills/cello/
├── SKILL.md          # entry point: auth/setup + topic routing
├── nodes.md          # list peers/orderers, status, counts
├── channels.md       # list channels
├── chaincodes.md     # list chaincodes (version/status/approvals)
└── organizations.md  # list/get organizations
```

## Features (current)

- **Read-only inspection** of nodes (PEER/ORDERER + live status), channels, chaincodes, and organizations.
- **Authentication** via the existing JWT flow:
  - logs in through `POST /login` with a service-account email/password,
  - caches the access token in `~/.cello/token`,
  - sends it as `Authorization: JWT <token>`,
- **Graceful failure**: if the credentials file is missing or login fails, the agent is instructed to stop and tell the user, instead of fabricating data.

## How to use

1. Have a Cello API Engine running (default base URL `http://localhost:8080/api/v1`).
2. Create a credentials file for an existing Cello user (env-style, `chmod 600`):
   ```bash
   mkdir -p ~/.cello
   cat > ~/.cello/credentials <<'EOF'
   CELLO_EMAIL=you@example.com
   CELLO_PASSWORD=your-password
   EOF
   chmod 600 ~/.cello/credentials
   ```
3. Open this repo in Claude Code and ask in natural language, e.g.:
   - "List the peers and orderers in my Cello network and their status."
   - "What chaincodes are deployed, and on which channels?"

   The skill loads automatically, logs in, and answers from the API.

## Testing

- With a running Cello and a valid `~/.cello/credentials`, listing nodes/channels/chaincodes/organizations returns live data.
- With no service running (or no credentials file), the agent reports a clear, actionable error instead of fabricating results.