### PR TITLE
fix: start complete local development stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ LOCAL_STORAGE_PATH=/opt/cello
 LOCAL_COMPOSE_FILE ?= docker-compose.dev.yaml
 LOCAL_AGENT_NAME ?= cello-docker-agent
 LOCAL_AGENT_IMAGE ?= cello/hyperledger-fabric-agent:local
-LOCAL_AGENT_VOLUME ?= cello-hyperledger-fabric-agent
 LOCAL_AGENT_PORT ?= 5001
 LOCAL_AGENT_INTERNAL_PORT ?= 8080
 LOCAL_AGENT_URL ?= http://$(LOCAL_AGENT_NAME):$(LOCAL_AGENT_INTERNAL_PORT)/api/v1/
@@ -173,15 +172,13 @@ help: ##@Help Show this help.
 license:  ##@Code Check source files for Apache license header
 	scripts/check_license.sh
 
-local: fabric hyperledger-fabric-agent start-docker-compose start-local-agent ##@Development Run local API, dashboard, database, and Fabric agent
+local: fabric start-docker-compose ##@Development Run local API, dashboard, database, and Fabric agent
 	@echo "Cello dashboard: http://localhost:8081"
 	@echo "Cello API engine: http://localhost:8080"
 	@echo "Fabric agent health: http://localhost:$(LOCAL_AGENT_PORT)/api/v1/health"
 	@echo "Use this agent URL when registering: $(LOCAL_AGENT_URL)"
 
 local-reset:##@Development Remove local data and restart all local services
-	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
-	@-docker volume rm -f $(LOCAL_AGENT_VOLUME) >/dev/null 2>&1
 	docker compose -f $(LOCAL_COMPOSE_FILE) down -v --remove-orphans
 	$(MAKE) local
 
@@ -225,11 +222,11 @@ check-api: ##@Test Run API tests with newman
 	cd tests/postman && docker compose up --abort-on-container-exit || (echo "API tests failed $$?"; exit 1)
 
 start-docker-compose:
+	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
 	docker compose -f $(LOCAL_COMPOSE_FILE) up -d --build --force-recreate --remove-orphans
 
 stop-docker-compose:
 	echo "Stop all services with $(LOCAL_COMPOSE_FILE)..."
-	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
 	docker compose -f $(LOCAL_COMPOSE_FILE) stop
 	echo "Stop all services successfully"
 
@@ -243,13 +240,6 @@ docker-rest-agent:
 
 fabric:
 	docker build -t hyperledger/fabric:$(HLF_FABRIC_VERSION) src/nodes/hyperledger-fabric
-
-hyperledger-fabric-agent:
-	docker build -t $(LOCAL_AGENT_IMAGE) src/agents/hyperledger-fabric
-
-start-local-agent:
-	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
-	docker run -d --restart unless-stopped --name $(LOCAL_AGENT_NAME) --hostname $(LOCAL_AGENT_NAME) --network cello-net -p $(LOCAL_AGENT_PORT):$(LOCAL_AGENT_INTERNAL_PORT) -v /var/run/docker.sock:/var/run/docker.sock -v $(LOCAL_AGENT_VOLUME):/cello $(LOCAL_AGENT_IMAGE)
 
 dashboard:
 	docker build -t hyperledger/cello-dashboard:latest -f build_image/docker/common/dashboard/Dockerfile.in ./
@@ -278,7 +268,6 @@ agent:
 	deep-clean \
 	api-engine \
 	fabric \
-	hyperledger-fabric-agent \
 	dashboard \
 	docker-compose \
 	reset \
@@ -286,7 +275,6 @@ agent:
 	local-reset \
 	clean-images \
 	start-docker-compose \
-	start-local-agent \
 	stop-docker-compose \
 	images \
 	server \

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,13 @@ endif
 SERVER_PUBLIC_IP ?= 127.0.0.1
 
 LOCAL_STORAGE_PATH=/opt/cello
+LOCAL_COMPOSE_FILE ?= docker-compose.dev.yaml
+LOCAL_AGENT_NAME ?= cello-docker-agent
+LOCAL_AGENT_IMAGE ?= cello/hyperledger-fabric-agent:local
+LOCAL_AGENT_PORT ?= 5001
+LOCAL_AGENT_INTERNAL_PORT ?= 8080
+LOCAL_AGENT_URL ?= http://$(LOCAL_AGENT_NAME):$(LOCAL_AGENT_INTERNAL_PORT)/api/v1/
+HLF_FABRIC_VERSION ?= 2.5.15
 
 # Docker images needed to run cello services
 COMMON_DOCKER_IMAGES = api-engine nginx dashboard
@@ -165,8 +172,16 @@ help: ##@Help Show this help.
 license:  ##@Code Check source files for Apache license header
 	scripts/check_license.sh
 
-local:##@Development Run all services ad-hoc
-	make docker-compose start-docker-compose 
+local: fabric hyperledger-fabric-agent start-docker-compose start-local-agent ##@Development Run local API, dashboard, database, and Fabric agent
+	@echo "Cello dashboard: http://localhost:8081"
+	@echo "Cello API engine: http://localhost:8080"
+	@echo "Fabric agent health: http://localhost:$(LOCAL_AGENT_PORT)/api/v1/health"
+	@echo "Use this agent URL when registering: $(LOCAL_AGENT_URL)"
+
+local-reset:##@Development Remove local data and restart all local services
+	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
+	docker compose -f $(LOCAL_COMPOSE_FILE) down -v --remove-orphans
+	$(MAKE) local
 
 reset:##@Development Clean up and remove local storage (only use for development)
 	make clean 
@@ -208,11 +223,12 @@ check-api: ##@Test Run API tests with newman
 	cd tests/postman && docker compose up --abort-on-container-exit || (echo "API tests failed $$?"; exit 1)
 
 start-docker-compose:
-	docker compose -f docker-compose.dev.yaml up -d --build --force-recreate --remove-orphans
+	docker compose -f $(LOCAL_COMPOSE_FILE) up -d --build --force-recreate --remove-orphans
 
 stop-docker-compose:
-	echo "Stop all services with bootup/docker-compose-files/${COMPOSE_FILE}..."
-	docker compose -f bootup/docker-compose-files/${COMPOSE_FILE} stop
+	echo "Stop all services with $(LOCAL_COMPOSE_FILE)..."
+	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
+	docker compose -f $(LOCAL_COMPOSE_FILE) stop
 	echo "Stop all services successfully"
 
 images: api-engine docker-rest-agent fabric dashboard
@@ -224,7 +240,14 @@ docker-rest-agent:
 	docker build -t hyperledger/cello-agent-docker:latest -f build_image/docker/agent/docker-rest-agent/Dockerfile.in ./ --build-arg pip=$(PIP) --platform linux/$(ARCH)
 
 fabric:
-	docker build -t hyperledger/fabric:2.5.14 src/nodes/hyperledger-fabric
+	docker build -t hyperledger/fabric:$(HLF_FABRIC_VERSION) src/nodes/hyperledger-fabric
+
+hyperledger-fabric-agent:
+	docker build -t $(LOCAL_AGENT_IMAGE) src/agents/hyperledger-fabric
+
+start-local-agent:
+	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
+	docker run -d --name $(LOCAL_AGENT_NAME) --hostname $(LOCAL_AGENT_NAME) --network cello-net -p $(LOCAL_AGENT_PORT):$(LOCAL_AGENT_INTERNAL_PORT) -v /var/run/docker.sock:/var/run/docker.sock $(LOCAL_AGENT_IMAGE)
 
 dashboard:
 	docker build -t hyperledger/cello-dashboard:latest -f build_image/docker/common/dashboard/Dockerfile.in ./
@@ -253,12 +276,15 @@ agent:
 	deep-clean \
 	api-engine \
 	fabric \
+	hyperledger-fabric-agent \
 	dashboard \
 	docker-compose \
 	reset \
 	local \
+	local-reset \
 	clean-images \
 	start-docker-compose \
+	start-local-agent \
 	stop-docker-compose \
 	images \
 	server \

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ LOCAL_STORAGE_PATH=/opt/cello
 LOCAL_COMPOSE_FILE ?= docker-compose.dev.yaml
 LOCAL_AGENT_NAME ?= cello-docker-agent
 LOCAL_AGENT_IMAGE ?= cello/hyperledger-fabric-agent:local
+LOCAL_AGENT_VOLUME ?= cello-hyperledger-fabric-agent
 LOCAL_AGENT_PORT ?= 5001
 LOCAL_AGENT_INTERNAL_PORT ?= 8080
 LOCAL_AGENT_URL ?= http://$(LOCAL_AGENT_NAME):$(LOCAL_AGENT_INTERNAL_PORT)/api/v1/
@@ -180,6 +181,7 @@ local: fabric hyperledger-fabric-agent start-docker-compose start-local-agent ##
 
 local-reset:##@Development Remove local data and restart all local services
 	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
+	@-docker volume rm -f $(LOCAL_AGENT_VOLUME) >/dev/null 2>&1
 	docker compose -f $(LOCAL_COMPOSE_FILE) down -v --remove-orphans
 	$(MAKE) local
 
@@ -247,7 +249,7 @@ hyperledger-fabric-agent:
 
 start-local-agent:
 	@-docker rm -f $(LOCAL_AGENT_NAME) >/dev/null 2>&1
-	docker run -d --name $(LOCAL_AGENT_NAME) --hostname $(LOCAL_AGENT_NAME) --network cello-net -p $(LOCAL_AGENT_PORT):$(LOCAL_AGENT_INTERNAL_PORT) -v /var/run/docker.sock:/var/run/docker.sock $(LOCAL_AGENT_IMAGE)
+	docker run -d --restart unless-stopped --name $(LOCAL_AGENT_NAME) --hostname $(LOCAL_AGENT_NAME) --network cello-net -p $(LOCAL_AGENT_PORT):$(LOCAL_AGENT_INTERNAL_PORT) -v /var/run/docker.sock:/var/run/docker.sock -v $(LOCAL_AGENT_VOLUME):/cello $(LOCAL_AGENT_IMAGE)
 
 dashboard:
 	docker build -t hyperledger/cello-dashboard:latest -f build_image/docker/common/dashboard/Dockerfile.in ./

--- a/README.md
+++ b/README.md
@@ -52,26 +52,31 @@ If environment is prepared, then we can start cello service.
   $ make local
   ```
 
-* Optional: Build essential images for cello service (the docker hub image auto build haven't ready, in the future you can ignore this step.)
+  This command builds the required local images and starts the dashboard, API
+  engine, PostgreSQL database, and Fabric agent.
 
-  * Build docker images
-    ```bash
-    $ make docker
-    ```
-  * Then run services locally then
+* If you need a clean local environment, remove the local data volume and
+  restart all services:
 
-    ```bash
-    $ make start
-    ```
+  ```bash
+  $ make local-reset
+  ```
 
 * After service started up, if use docker-compose method, you can see output:
 
   ```bash
-  CONTAINER ID   IMAGE                            COMMAND                  CREATED         STATUS         PORTS                                                                                  NAMES
-  81e6459965ec   hyperledger/cello-agent-docker   "gunicorn server:app…"   4 seconds ago   Up 2 seconds   0.0.0.0:2375->2375/tcp, :::2375->2375/tcp, 0.0.0.0:5001->5001/tcp, :::5001->5001/tcp   cello.docker.agent
-  04367ab6bd5e   postgres:11.1                    "docker-entrypoint.s…"   4 seconds ago   Up 2 seconds   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp                                              cello-postgres
-  29b56a279893   hyperledger/cello-api-engine     "/bin/sh -c 'bash /e…"   4 seconds ago   Up 2 seconds   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp                                              cello-api-engine
-  a272a06d8280   hyperledger/cello-dashboard      "bash -c 'nginx -g '…"   4 seconds ago   Up 2 seconds   80/tcp, 0.0.0.0:8081->8081/tcp, :::8081->8081/tcp                                      cello-dashboard
+  CONTAINER ID   IMAGE                                   COMMAND                  CREATED         STATUS         PORTS                                       NAMES
+  57df1462c7f1   cello/hyperledger-fabric-agent:local    "python manage.py r…"    4 seconds ago   Up 2 seconds   0.0.0.0:5001->8080/tcp, :::5001->8080/tcp   cello-docker-agent
+  04367ab6bd5e   postgres:12.0                           "docker-entrypoint.s…"   4 seconds ago   Up 2 seconds   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp   cello-postgres
+  29b56a279893   cello/api-engine:latest                 "/bin/sh -c 'bash /e…"   4 seconds ago   Up 2 seconds   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp   cello-api-engine
+  a272a06d8280   cello/dashboard:latest                  "bash -c 'nginx -g '…"   4 seconds ago   Up 2 seconds   0.0.0.0:8081->8081/tcp, :::8081->8081/tcp   cello-dashboard
+  ```
+
+* When registering an organization from the dashboard, use the following agent
+  URL:
+
+  ```text
+  http://cello-docker-agent:8080/api/v1/
   ```
 
 * Stop cello service.<!---, same as start, need set the `DEPLOY_METHOD` variable.-->

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -55,6 +55,21 @@ services:
     depends_on:
       - cello-postgres
 
+  cello-docker-agent:
+    build:
+      context: ./src/agents/hyperledger-fabric
+    image: "${LOCAL_AGENT_IMAGE:-cello/hyperledger-fabric-agent:local}"
+    container_name: "${LOCAL_AGENT_NAME:-cello-docker-agent}"
+    hostname: "${LOCAL_AGENT_NAME:-cello-docker-agent}"
+    restart: unless-stopped
+    ports:
+      - "${LOCAL_AGENT_PORT:-5001}:${LOCAL_AGENT_INTERNAL_PORT:-8080}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - cello-hyperledger-fabric-agent:/cello
+    networks:
+      - cello-net
+
 networks:
   cello-net:
     name: cello-net
@@ -63,3 +78,4 @@ volumes:
   cello-postgres:
   cello-api-engine:
   cello-api-engine-chaincode:
+  cello-hyperledger-fabric-agent:


### PR DESCRIPTION
**PR Description**

This PR updates the local development workflow so `make local` starts a complete Cello environment through Docker Compose.

**Changes**

- Update `make local` to start the full local stack:
  - Build `hyperledger/fabric:2.5.15`
  - Start dashboard, api-engine, PostgreSQL, and Fabric agent
- Add `cello-docker-agent` to `docker-compose.dev.yaml`
  - Builds from `src/agents/hyperledger-fabric`
  - Uses image `cello/hyperledger-fabric-agent:local`
  - Exposes agent health on `localhost:5001`
  - Joins the shared `cello-net` network
  - Mounts Docker socket so the agent can create Fabric node containers
  - Persists agent runtime artifacts under `/cello` with a named volume
- Add `make local-reset` for clean local restarts:
  - Runs `docker compose down -v`
  - Calls `make local`
- Align the Fabric node image version from `2.5.14` to `2.5.15`
- Simplify Makefile by removing the manual `docker run` path for the Fabric agent
- Update README Quick Start to document:
  - The new `make local` behavior
  - The new `make local-reset` command
  - The current local containers
  - The agent URL to use during organization registration:
    `http://cello-docker-agent:8080/api/v1/`



**Verification**

Tested locally with:

```bash
make local
```